### PR TITLE
[Team-09][BE][테리&벅픽] 2주차 PR 1번째 - 로그인 API 구현 마무리, Issue 저장 API 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
 	// webflux
 	compileOnly 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/BE/docs/issue_tracker_table_create.sql
+++ b/BE/docs/issue_tracker_table_create.sql
@@ -17,7 +17,8 @@ USE `issue_tracker` ;
 -- -----------------------------------------------------
 create TABLE IF NOT EXISTS `issue_tracker`.`member` (
   `member_id` BIGINT NOT NULL AUTO_INCREMENT,
-  `user_id` VARCHAR(20) NULL DEFAULT NULL,
+  `user_id` VARCHAR(20) NULL DEFAULT NULL UNIQUE,
+  `email` VARCHAR(20) NULL DEFAULT NULL,
   `name` VARCHAR(20) NULL DEFAULT NULL,
   `type` VARCHAR(10) NULL DEFAULT NULL,  
   `img_url` VARCHAR(100) NULL DEFAULT NULL,

--- a/BE/docs/issue_tracker_table_create.sql
+++ b/BE/docs/issue_tracker_table_create.sql
@@ -164,6 +164,8 @@ create TABLE IF NOT EXISTS `issue_tracker`.`issue_label` (
   `issue_label_id` BIGINT NOT NULL AUTO_INCREMENT,
   `issue_id` BIGINT NULL DEFAULT NULL,
   `label_id` BIGINT NULL DEFAULT NULL,
+  `created_at` DATETIME(6) NULL DEFAULT (CURRENT_TIME),
+  `modified_at` DATETIME(6) NULL DEFAULT (CURRENT_TIME),
 --  `member_id` BIGINT NULL DEFAULT NULL, -- 없어져도 될 것
   PRIMARY KEY (`issue_label_id`),
   INDEX `fk_issue_label_issue_id` (`issue_id` ASC) VISIBLE,
@@ -191,6 +193,8 @@ create TABLE IF NOT EXISTS `issue_tracker`.`issue_member` (
   `issue_member_id` BIGINT NOT NULL AUTO_INCREMENT,
   `member_id` BIGINT NULL DEFAULT NULL,
   `issue_id` BIGINT NULL DEFAULT NULL,
+  `created_at` DATETIME(6) NULL DEFAULT (CURRENT_TIME),
+  `modified_at` DATETIME(6) NULL DEFAULT (CURRENT_TIME),
   PRIMARY KEY (`issue_member_id`),
   INDEX `fk_issue_member_member_id` (`member_id` ASC) VISIBLE,
   INDEX `fk_issue_member_issue_id` (`issue_id` ASC) VISIBLE,
@@ -205,4 +209,4 @@ DEFAULT CHARACTER SET = utf8mb4
 COLLATE = utf8mb4_0900_ai_ci;
 
 -- TODO : 해당 제약 사항, 컬럼 순서 무엇이 좋을 지 확인하기
-ALTER TABLE issue_member ADD UNIQUE (member_id, issue_id);
+ALTER TABLE issue_member ADD UNIQUE (issue_id, member_id);

--- a/BE/src/main/java/com/team09/issue_tracker/common/ErrorResponse.java
+++ b/BE/src/main/java/com/team09/issue_tracker/common/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.team09.issue_tracker.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse<T> {
+
+	private final T message;
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/BusinessException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/BusinessException.java
@@ -1,0 +1,10 @@
+package com.team09.issue_tracker.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class BusinessException extends RuntimeException {
+
+	protected abstract HttpStatus getHttpStatus();
+
+	protected abstract String getBodyMessage();
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/CustomExceptionHandler.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/CustomExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.team09.issue_tracker.exception;
+
+import com.team09.issue_tracker.common.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse<String>> handleBusinessException(
+		BusinessException exception) {
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(new ErrorResponse<>(exception.getBodyMessage()));
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/EditorInvalidException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/EditorInvalidException.java
@@ -1,0 +1,9 @@
+package com.team09.issue_tracker.exception;
+
+public class EditorInvalidException extends InvalidException{
+
+	@Override
+	protected String getBodyMessage() {
+		return "편집할 수 있는 사용자가 아닙니다.";
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/InvalidException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/InvalidException.java
@@ -1,0 +1,11 @@
+package com.team09.issue_tracker.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class InvalidException extends BusinessException {
+
+	@Override
+	protected HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/LabelInvalidException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/LabelInvalidException.java
@@ -1,0 +1,9 @@
+package com.team09.issue_tracker.exception;
+
+public class LabelInvalidException extends InvalidException{
+
+	@Override
+	protected String getBodyMessage() {
+		return "labelId가 올바르지 않습니다.";
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/MemberInvalidException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/MemberInvalidException.java
@@ -1,0 +1,9 @@
+package com.team09.issue_tracker.exception;
+
+public class MemberInvalidException extends InvalidException{
+
+	@Override
+	protected String getBodyMessage() {
+		return "memberId가 올바르지 않습니다.";
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/exception/MilestoneInvalidException.java
+++ b/BE/src/main/java/com/team09/issue_tracker/exception/MilestoneInvalidException.java
@@ -1,0 +1,9 @@
+package com.team09.issue_tracker.exception;
+
+public class MilestoneInvalidException extends InvalidException {
+
+	@Override
+	protected String getBodyMessage() {
+		return "milestoneId가 올바르지 않습니다.";
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/issue/IssueController.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/IssueController.java
@@ -48,29 +48,9 @@ public class IssueController {
 		@RequestBody IssueSaveRequestDto issueCreateRequestDto) {
 
 		validateCreateRequestDto(issueCreateRequestDto);
-
-		//이슈 생성
 		CommonResponseDto response = issueService.create(issueCreateRequestDto, MEMBER_ID);
 
 		return ResponseEntity.ok().body(response);
-	}
-
-	private void validateCreateRequestDto(IssueSaveRequestDto issueCreateRequestDto) {
-		//mileStoneId 검증
-		if (issueCreateRequestDto.getMilestoneId() != null) {
-			issueValidateService.validateMyMilestoneId(
-				issueCreateRequestDto.getMilestoneId(), MEMBER_ID);
-		}
-
-		//labelsIds 검증
-		if (issueCreateRequestDto.getLabelIds() != null) {
-			issueValidateService.validateMyLabelIds(issueCreateRequestDto.getLabelIds(), MEMBER_ID);
-		}
-
-		//assigneeIds 검증
-		if (issueCreateRequestDto.getAssigneeIds() != null) {
-			issueValidateService.validateMember(issueCreateRequestDto.getAssigneeIds());
-		}
 	}
 
 	@DeleteMapping("/{id}")
@@ -100,5 +80,23 @@ public class IssueController {
 	public ResponseEntity<CommonResponseDto> updateAllState(@RequestParam final Boolean isClose,
 		@RequestBody final IssueSaveRequestDto issueUpdateAllRequestDto) {
 		return ResponseEntity.ok(new CommonResponseDto());
+	}
+
+	private void validateCreateRequestDto(IssueSaveRequestDto issueCreateRequestDto) {
+		//mileStoneId 검증
+		if (issueCreateRequestDto.getMilestoneId() != null) {
+			issueValidateService.validateMyMilestoneId(
+				issueCreateRequestDto.getMilestoneId(), MEMBER_ID);
+		}
+
+		//labelsIds 검증
+		if (issueCreateRequestDto.getLabelIds() != null) {
+			issueValidateService.validateMyLabelIds(issueCreateRequestDto.getLabelIds(), MEMBER_ID);
+		}
+
+		//assigneeIds 검증
+		if (issueCreateRequestDto.getAssigneeIds() != null) {
+			issueValidateService.validateMember(issueCreateRequestDto.getAssigneeIds());
+		}
 	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/issue/IssueLabelRepository.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/IssueLabelRepository.java
@@ -1,0 +1,8 @@
+package com.team09.issue_tracker.issue;
+
+import com.team09.issue_tracker.issue.domain.IssueLabel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueLabelRepository extends JpaRepository<IssueLabel, Long> {
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/issue/IssueRepository.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/IssueRepository.java
@@ -1,7 +1,9 @@
 package com.team09.issue_tracker.issue;
 
 import com.team09.issue_tracker.issue.domain.Issue;
+import com.team09.issue_tracker.milestone.Milestone;
 import java.util.List;
+import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +12,5 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
 	@EntityGraph(attributePaths = {"milestone", "issueLabels", "issueLabels.label"})
 	List<Issue> findByMemberIdAndIsOpened(Long memberId, boolean isOpened);
 
+	Stream<Issue> findByMilestone(Milestone milestone);
 }

--- a/BE/src/main/java/com/team09/issue_tracker/issue/IssueService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/IssueService.java
@@ -1,11 +1,16 @@
 package com.team09.issue_tracker.issue;
 
 import com.team09.issue_tracker.common.CommonResponseDto;
+import com.team09.issue_tracker.exception.EditorInvalidException;
 import com.team09.issue_tracker.issue.domain.Issue;
 import com.team09.issue_tracker.issue.domain.IssueAssignee;
+import com.team09.issue_tracker.issue.domain.IssueLabel;
 import com.team09.issue_tracker.issue.dto.IssueDetailResponseDto;
 import com.team09.issue_tracker.issue.dto.IssueSaveRequestDto;
 import com.team09.issue_tracker.issue.dto.IssueListResponseDto;
+import com.team09.issue_tracker.issue.dto.IssueSaveServiceDto;
+import com.team09.issue_tracker.member.Member;
+import com.team09.issue_tracker.milestone.Milestone;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IssueService {
 
 	private final IssueRepository issueRepository;
+	private final IssueLabelRepository issueLabelRepository;
 	private final IssueAssigneeRepository issueAssigneeRepository;
 
 	@Transactional(readOnly = true)
@@ -36,32 +42,80 @@ public class IssueService {
 		Long milestoneId = issueCreateRequestDto.getMilestoneId();
 		List<Long> labelIds = issueCreateRequestDto.getLabelIds();
 		List<Long> assigneeIds = issueCreateRequestDto.getAssigneeIds();
-		if (milestoneId != null && labelIds != null && assigneeIds != null) {
-			return null;
-		}
 
 		boolean isOpened = true;
-		Issue issue = issueRepository.save(
-			Issue.fromForMandatory(issueCreateRequestDto, isOpened, memberId));
-		CommonResponseDto response = issue.toCommonResponse();
-		return response;
+
+		//1. Milestone 생성
+		Milestone milestone = null;
+		if (milestoneId != null) {
+			milestone = Milestone.of(milestoneId);
+		}
+
+		//2. Issue 생성
+		IssueSaveServiceDto issueSaveServiceDto = IssueSaveServiceDto.builder()
+			.title(issueCreateRequestDto.getTitle())
+			.content(issueCreateRequestDto.getContent())
+			.milestone(milestone)
+			.isOpened(isOpened)
+			.memberId(memberId)
+			.build();
+		Issue issue = Issue.from(issueSaveServiceDto);
+
+		//Issue 저장
+		Issue savedIssue = issueRepository.save(issue);
+		Long issueId = savedIssue.getId();
+
+		//3. IssueLabel 생성
+		if (labelIds.size() > 0) {
+			List<IssueLabel> issueLabels = labelIds.stream()
+				.map(labelId -> IssueLabel.of(issueId, labelId))
+				.collect(Collectors.toList());
+
+			List<IssueLabel> savedIssueLabels = issueLabels.stream()
+				.map(issueLabel -> issueLabelRepository.save(issueLabel))
+				.collect(Collectors.toList());
+			//연관관계 편의 메서드
+			savedIssue.addIssueLabel(savedIssueLabels);
+		}
+
+		//4. IssueAssignee 생성
+		if (assigneeIds.size() > 0) {
+			List<IssueAssignee> issueAssignees = assigneeIds.stream()
+				.map(assigneeId -> IssueAssignee.of(savedIssue, Member.of(assigneeId)))
+				.collect(Collectors.toList());
+
+			List<IssueAssignee> savedIssueAssignees = issueAssignees.stream()
+				.map(issueAssignee -> issueAssigneeRepository.save(issueAssignee))
+				.collect(Collectors.toList());
+			//연관관계 편의메서드
+			issue.addIssueAssignee(savedIssueAssignees);
+		}
+
+		return savedIssue.toCommonResponse();
 	}
 
+	/**
+	 * 해당 issueid가 작성/할당 된 이슈만 "더보기" 버튼 생성 하여 상세정보 수정/삭제 가능 작성자, 할당자 확인 로직
+	 *
+	 * @param issueId
+	 * @param memberId
+	 * @return
+	 */
 	@Transactional(readOnly = true)
-	public IssueDetailResponseDto selectOneById(Long issueId, Long memberId) {
-		// TODO : id가 작성/할당 된 이슈만 "더보기" 버튼 생성 하여 상세정보 수정/삭제 가능
+	public IssueDetailResponseDto selectDetailById(Long issueId, Long memberId) {
 		boolean isEditable = false;
 
 		//1. 조회하면서 작성자인지 확인
 		Issue issue = issueRepository.findById(issueId)
-			.orElseThrow(() -> new RuntimeException("")); // TODO: 커스텀 익셉션 생성
+			.orElseThrow(() -> new EditorInvalidException());
 
 		if (issue.isWriter(memberId)) {
 			isEditable = true;
+			return issue.toDetailResponse(isEditable);
 		}
 
 		//2. 할당자인지 확인
-		List<IssueAssignee> issueAssignees = issueAssigneeRepository.findByIssueId(issue.getId());
+		List<IssueAssignee> issueAssignees = issue.getIssueAssignees();
 		if (issueAssignees.size() != 0) {
 			isEditable = true;
 		}

--- a/BE/src/main/java/com/team09/issue_tracker/issue/IssueValidateService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/IssueValidateService.java
@@ -1,0 +1,39 @@
+package com.team09.issue_tracker.issue;
+
+import com.team09.issue_tracker.exception.LabelInvalidException;
+import com.team09.issue_tracker.exception.MemberInvalidException;
+import com.team09.issue_tracker.exception.MilestoneInvalidException;
+import com.team09.issue_tracker.label.LabelService;
+import com.team09.issue_tracker.member.MemberService;
+import com.team09.issue_tracker.milestone.MilestoneService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class IssueValidateService {
+
+	private final MilestoneService milestoneService;
+	private final LabelService labelService;
+	private final MemberService memberService;
+
+	public void validateMyMilestoneId(Long milestoneId, Long memberId) {
+		if (!milestoneService.isMyMilestone(milestoneId, memberId)) {
+			throw new MilestoneInvalidException();
+		}
+	}
+
+	public void validateMyLabelIds(List<Long> labelIds, Long memberId) {
+		if (!labelService.isMyLabels(labelIds, memberId)) {
+			throw new LabelInvalidException();
+		}
+	}
+
+	public void validateMember(List<Long> assigneeIds) {
+		if (!memberService.validateMemberIds(assigneeIds)) {
+			throw new MemberInvalidException();
+		}
+	}
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/issue/domain/Issue.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/domain/Issue.java
@@ -3,8 +3,8 @@ package com.team09.issue_tracker.issue.domain;
 import com.team09.issue_tracker.common.BaseTimeEntity;
 import com.team09.issue_tracker.common.CommonResponseDto;
 import com.team09.issue_tracker.issue.dto.IssueDetailResponseDto;
-import com.team09.issue_tracker.issue.dto.IssueSaveRequestDto;
 import com.team09.issue_tracker.issue.dto.IssueListResponseDto;
+import com.team09.issue_tracker.issue.dto.IssueSaveServiceDto;
 import com.team09.issue_tracker.label.Label;
 import com.team09.issue_tracker.milestone.Milestone;
 import java.util.ArrayList;
@@ -23,8 +23,10 @@ import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,6 +53,9 @@ public class Issue extends BaseTimeEntity {
 	@OneToMany(mappedBy = "issue", fetch = FetchType.LAZY)
 	private List<IssueLabel> issueLabels = new ArrayList<>();
 
+	@OneToMany(mappedBy = "issue", fetch = FetchType.LAZY)
+	private List<IssueAssignee> issueAssignees = new ArrayList<>();
+
 	public boolean isWriter(Long memberId) {
 		if (memberId.equals(this.memberId)) {
 			return true;
@@ -58,25 +63,28 @@ public class Issue extends BaseTimeEntity {
 		return false;
 	}
 
-	public Long getId() {
-		return id;
+	public void addIssueLabel(List<IssueLabel> issueLabels) {
+		this.issueLabels = issueLabels;
 	}
 
-	public String getTitle() {
-		return title;
+	public void addIssueAssignee(List<IssueAssignee> issueAssignees) {
+		this.issueAssignees = issueAssignees;
 	}
 
-	public String getContent() {
-		return content;
-	}
-
-	public static Issue fromForMandatory(IssueSaveRequestDto issueSaveRequestDto,
-		boolean isOpened, Long memberId) {
+	public static Issue of(Long issueId) {
 		return Issue.builder()
-			.title(issueSaveRequestDto.getTitle())
-			.content(issueSaveRequestDto.getContent())
-			.isOpened(isOpened)
-			.memberId(memberId)
+			.id(issueId)
+			.build();
+	}
+
+	public static Issue from(IssueSaveServiceDto issueSaveServiceDto) {
+		return Issue.builder()
+			.title(issueSaveServiceDto.getTitle())
+			.content(issueSaveServiceDto.getContent())
+			.milestone(issueSaveServiceDto.getMilestone())
+			.issueLabels(issueSaveServiceDto.getIssueLabels())
+			.isOpened(issueSaveServiceDto.isOpened())
+			.memberId(issueSaveServiceDto.getMemberId())
 			.build();
 	}
 

--- a/BE/src/main/java/com/team09/issue_tracker/issue/domain/Issue.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/domain/Issue.java
@@ -57,10 +57,7 @@ public class Issue extends BaseTimeEntity {
 	private List<IssueAssignee> issueAssignees = new ArrayList<>();
 
 	public boolean isWriter(Long memberId) {
-		if (memberId.equals(this.memberId)) {
-			return true;
-		}
-		return false;
+		return memberId.equals(this.memberId);
 	}
 
 	public void addIssueLabel(List<IssueLabel> issueLabels) {

--- a/BE/src/main/java/com/team09/issue_tracker/issue/domain/IssueAssignee.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/domain/IssueAssignee.java
@@ -1,5 +1,6 @@
 package com.team09.issue_tracker.issue.domain;
 
+import com.team09.issue_tracker.common.BaseTimeEntity;
 import com.team09.issue_tracker.member.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -10,10 +11,19 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "issue_member")
-public class IssueAssignee {
+public class IssueAssignee extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +38,10 @@ public class IssueAssignee {
 	@JoinColumn(name = "issue_id")
 	private Issue issue;
 
+	public static IssueAssignee of(Issue issue, Member writer) {
+		return IssueAssignee.builder()
+			.issue(issue)
+			.writer(writer)
+			.build();
+	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/issue/domain/IssueLabel.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/domain/IssueLabel.java
@@ -1,5 +1,6 @@
 package com.team09.issue_tracker.issue.domain;
 
+import com.team09.issue_tracker.common.BaseTimeEntity;
 import com.team09.issue_tracker.label.Label;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,11 +10,18 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class IssueLabel {
+public class IssueLabel extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +35,12 @@ public class IssueLabel {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "label_id")
 	private Label label;
+
+	public static IssueLabel of(Long issueId, Long labelId) {
+		return IssueLabel.builder()
+			.issue(Issue.of(issueId))
+			.label(Label.of(labelId))
+			.build();
+	}
+
 }

--- a/BE/src/main/java/com/team09/issue_tracker/issue/dto/IssueSaveServiceDto.java
+++ b/BE/src/main/java/com/team09/issue_tracker/issue/dto/IssueSaveServiceDto.java
@@ -1,0 +1,25 @@
+package com.team09.issue_tracker.issue.dto;
+
+import com.team09.issue_tracker.issue.domain.IssueLabel;
+import com.team09.issue_tracker.member.Member;
+import com.team09.issue_tracker.milestone.Milestone;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueSaveServiceDto {
+
+	private String title;
+	private String content;
+	private Milestone milestone;
+	private List<IssueLabel> issueLabels;
+	private boolean isOpened;
+	private Long memberId;
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/label/Label.java
+++ b/BE/src/main/java/com/team09/issue_tracker/label/Label.java
@@ -6,8 +6,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Transient;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Label {
 
@@ -24,8 +30,15 @@ public class Label {
 
 	private String backgroundColor;
 
-	@Transient
-	private Long writerId;
+	private Long memberId;
+
+
+	public static Label of(Long labelid) {
+		return Label.builder()
+			.id(labelid)
+			.build();
+	}
+
 
 	public LabelSelectResponseDto toResponseDto() {
 		return LabelSelectResponseDto.builder()

--- a/BE/src/main/java/com/team09/issue_tracker/label/LabelRepository.java
+++ b/BE/src/main/java/com/team09/issue_tracker/label/LabelRepository.java
@@ -1,0 +1,15 @@
+package com.team09.issue_tracker.label;
+
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LabelRepository extends JpaRepository<Label, Long> {
+
+	//하나라도 존재하면 true
+	boolean existsByIdInAndMemberId(Set<Long> ids, Long memberId);
+	boolean existsByIdAndMemberId(Long id, Long memberId);
+
+	long countByIdInAndMemberId(List<Long> ids, Long memberId);
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/label/LabelService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/label/LabelService.java
@@ -1,0 +1,21 @@
+package com.team09.issue_tracker.label;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LabelService {
+
+	private final LabelRepository labelRepository;
+
+	public boolean isMyLabels(List<Long> labelIds, Long memberId) {
+		long countOfLabelFromDb = labelRepository.countByIdInAndMemberId(labelIds, memberId);
+
+		if(countOfLabelFromDb == labelIds.size()){
+			return true;
+		}
+		return false;
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/label/LabelService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/label/LabelService.java
@@ -13,9 +13,6 @@ public class LabelService {
 	public boolean isMyLabels(List<Long> labelIds, Long memberId) {
 		long countOfLabelFromDb = labelRepository.countByIdInAndMemberId(labelIds, memberId);
 
-		if(countOfLabelFromDb == labelIds.size()){
-			return true;
-		}
-		return false;
+		return countOfLabelFromDb == labelIds.size();
 	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/login/controller/LoginController.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/controller/LoginController.java
@@ -1,11 +1,14 @@
 package com.team09.issue_tracker.login.controller;
 
 import com.team09.issue_tracker.login.controller.dto.LoginResponseDto;
+import com.team09.issue_tracker.login.controller.dto.TokenReissueRequestDto;
+import com.team09.issue_tracker.login.controller.dto.TokenReissueResponseDto;
 import com.team09.issue_tracker.login.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +27,9 @@ public class LoginController {
 		return ResponseEntity.ok(loginResponse);
 	}
 
-
+	@GetMapping("/oauth/reissue")
+	public ResponseEntity<TokenReissueResponseDto> reissue(
+		@RequestBody TokenReissueRequestDto reissueRequestDto) {
+		return ResponseEntity.ok(loginService.reissue(reissueRequestDto));
+	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/login/controller/dto/TokenReissueRequestDto.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/controller/dto/TokenReissueRequestDto.java
@@ -1,0 +1,12 @@
+package com.team09.issue_tracker.login.controller.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenReissueRequestDto {
+	private String accessToken;
+	private String refreshToken;
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/controller/dto/TokenReissueResponseDto.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/controller/dto/TokenReissueResponseDto.java
@@ -1,0 +1,19 @@
+package com.team09.issue_tracker.login.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenReissueResponseDto {
+
+	private String accessToken;
+	private String refreshToken;
+
+	@Builder
+	public TokenReissueResponseDto(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/filter/FilterConfiguration.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/filter/FilterConfiguration.java
@@ -1,0 +1,24 @@
+package com.team09.issue_tracker.login.filter;
+
+import com.team09.issue_tracker.login.jwt.JwtTokenProvider;
+import com.team09.issue_tracker.member.MemberService;
+import javax.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class FilterConfiguration {
+
+	private final JwtTokenProvider tokenProvider;
+	private final MemberService memberService;
+
+	@Bean
+	public FilterRegistrationBean<Filter> loginValidateFilter() {
+		LoginValidateFilter validateFilter = new LoginValidateFilter(tokenProvider, memberService);
+		return new FilterRegistrationBean<>(validateFilter);
+	}
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/filter/LoginValidateFilter.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/filter/LoginValidateFilter.java
@@ -1,0 +1,62 @@
+package com.team09.issue_tracker.login.filter;
+
+import com.team09.issue_tracker.login.jwt.JwtTokenProvider;
+import com.team09.issue_tracker.member.Member;
+import com.team09.issue_tracker.member.MemberRepository;
+import com.team09.issue_tracker.member.MemberService;
+import java.io.IOException;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginValidateFilter extends OncePerRequestFilter {
+
+	private static final String HEADER_AUTHORIZATION = "Authorization";
+	private static final String TOKEN_PREFIX = "Bearer ";
+	private static final String[] VALID_FREE_URLS = {"/login/*"};
+	private final JwtTokenProvider tokenProvider;
+	private final MemberService memberService;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String requestUrl = request.getRequestURI();
+		if (isValidRequiredUrl(requestUrl)) {
+			log.info("로그인 인증 유무 확인 로직 실행 ---> {}", requestUrl);
+			String accessToken = getAccessToken(request);
+			if (!tokenProvider.validateToken(accessToken)) {
+				throw new RuntimeException("유효하지 않은 JWT 토큰입니다!!");
+			}
+			addMemberIdToResponseHeader(accessToken, response);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private boolean isValidRequiredUrl(String requestUrl) {
+		return !PatternMatchUtils.simpleMatch(VALID_FREE_URLS, requestUrl);
+	}
+
+	private String getAccessToken(HttpServletRequest request) {
+		String header = Optional.ofNullable(request.getHeader(HEADER_AUTHORIZATION))
+			.orElseThrow(() -> new RuntimeException("JWT 토큰이 필요합니다!!"));
+		return header.substring(TOKEN_PREFIX.length());
+	}
+
+	private void addMemberIdToResponseHeader(String accessToken, HttpServletResponse response) {
+		String userId = (String) tokenProvider.parseClaims(accessToken).get("id");
+		log.info("유저 아이디 정보---> {}", userId);
+
+		Long id = memberService.findIdFromUserId(userId);
+
+		response.addHeader("userId", String.valueOf(id));
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtConfiguration.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtConfiguration.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class JwtConfig {
+public class JwtConfiguration {
 
 	@Value("${jwt.token.secret}")
 	private String jwtSecret;

--- a/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtToken.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtToken.java
@@ -12,7 +12,7 @@ public class JwtToken {
 	private final String accessToken;
 	private final String refreshToken;
 
-	JwtToken(Key key, long accessExpireTime, long refreshExpireTime, Long id, String userName) {
+	JwtToken(Key key, long accessExpireTime, long refreshExpireTime, String id, String userName) {
 		this.accessToken = createAccessToken(key, getExpireTime(accessExpireTime), id, userName);
 		this.refreshToken = createRefreshToken(key, getExpireTime(refreshExpireTime));
 	}
@@ -25,7 +25,7 @@ public class JwtToken {
 		return (new Date()).getTime();
 	}
 
-	private String createAccessToken(Key key, Date accessTokenExpireIn, Long id, String userName) {
+	private String createAccessToken(Key key, Date accessTokenExpireIn, String id, String userName) {
 		return Jwts.builder()
 			.setIssuer(userName)
 			.setExpiration(accessTokenExpireIn)

--- a/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtTokenProvider.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/jwt/JwtTokenProvider.java
@@ -15,7 +15,7 @@ public class JwtTokenProvider {
 
 	private final Key key;
 	private final long accessTokenExpireTime;
-	private final long refreshTokenExpireTime;
+	public final long refreshTokenExpireTime;
 
 	public JwtTokenProvider(String secret, long accessTokenExpireTime,
 		long refreshTokenExpireTime) {
@@ -24,7 +24,7 @@ public class JwtTokenProvider {
 		this.refreshTokenExpireTime = refreshTokenExpireTime;
 	}
 
-	public JwtToken createJwtToken(Long id, String userName) {
+	public JwtToken createJwtToken(String id, String userName) {
 		return new JwtToken(key, accessTokenExpireTime, refreshTokenExpireTime, id, userName);
 	}
 
@@ -32,7 +32,7 @@ public class JwtTokenProvider {
 		return parseClaims(token) != null;
 	}
 
-	private Claims parseClaims(String token) {
+	public Claims parseClaims(String token) {
 		try {
 			return Jwts.parserBuilder()
 				.setSigningKey(key)
@@ -44,9 +44,8 @@ public class JwtTokenProvider {
 		} catch (MalformedJwtException e) {
 			log.info("Invalid JWT token.");
 		} catch (ExpiredJwtException e) {
-			// TODO : 만료된 토큰 처리
 			log.info("Expired JWT token.");
-			return e.getClaims();
+			throw new RuntimeException("토큰이 만료되었습니다!!");
 		} catch (UnsupportedJwtException e) {
 			log.info("Unsupported JWT token.");
 		} catch (IllegalArgumentException e) {

--- a/BE/src/main/java/com/team09/issue_tracker/login/oauth/user/OauthUserProfile.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/oauth/user/OauthUserProfile.java
@@ -26,7 +26,7 @@ public class OauthUserProfile {
 
 	public Member toMember() {
 		return Member.builder()
-			.type(MemberType.valueOf(providerName))
+			.type(MemberType.getEnum(providerName))
 			.name(name)
 			.userId(userId)
 			.email(email)

--- a/BE/src/main/java/com/team09/issue_tracker/login/redis/RedisConfiguration.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/redis/RedisConfiguration.java
@@ -1,0 +1,30 @@
+package com.team09.issue_tracker.login.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfiguration {
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+		RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/redis/RedisService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/redis/RedisService.java
@@ -1,0 +1,30 @@
+package com.team09.issue_tracker.login.redis;
+
+import com.team09.issue_tracker.login.jwt.JwtTokenProvider;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final JwtTokenProvider tokenProvider;
+
+	public void setValue(String key, String data) {
+		ValueOperations<String, String> values = redisTemplate.opsForValue();
+		values.set(key, data, tokenProvider.refreshTokenExpireTime, TimeUnit.MILLISECONDS);
+	}
+
+	public String getValue(String key) {
+		ValueOperations<String, String> values = redisTemplate.opsForValue();
+		return values.get(key);
+	}
+
+	public void deleteValue(String key) {
+		redisTemplate.delete(key);
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/login/service/LoginService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/login/service/LoginService.java
@@ -1,6 +1,8 @@
 package com.team09.issue_tracker.login.service;
 
 import com.team09.issue_tracker.login.controller.dto.LoginResponseDto;
+import com.team09.issue_tracker.login.controller.dto.TokenReissueRequestDto;
+import com.team09.issue_tracker.login.controller.dto.TokenReissueResponseDto;
 import com.team09.issue_tracker.login.jwt.JwtToken;
 import com.team09.issue_tracker.login.jwt.JwtTokenProvider;
 import com.team09.issue_tracker.login.oauth.setup.OauthProvider;
@@ -9,10 +11,14 @@ import com.team09.issue_tracker.login.oauth.token.OauthAccessTokenProvider;
 import com.team09.issue_tracker.login.oauth.token.OauthAccessTokenResponse;
 import com.team09.issue_tracker.login.oauth.user.OauthUserProfile;
 import com.team09.issue_tracker.login.oauth.user.OauthUserProfileProvider;
+import com.team09.issue_tracker.login.redis.RedisService;
 import com.team09.issue_tracker.member.Member;
 import com.team09.issue_tracker.member.MemberService;
+import io.jsonwebtoken.Claims;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -21,26 +27,68 @@ public class LoginService {
 	private final OauthProviderInMemoryRepository oauthProviderRepository;
 	private final MemberService memberService;
 	private final JwtTokenProvider tokenProvider;
+	private final RedisService redisService;
 
+	@Transactional
 	public LoginResponseDto login(String providerName, String code) {
-
+		// providerName에 해당하는 provider의 속성값을 제공하는 OauthProvider 객체
 		OauthProvider oauthProvider = oauthProviderRepository.findByProviderName(providerName);
 
+		// provider로 부터 AccessToken 반환
 		OauthAccessTokenResponse tokenResponse = OauthAccessTokenProvider.getOauthAccessToken(
 			oauthProvider, code);
 
+		// AccessToken을 기반으로 사용자 정보 조회
 		OauthUserProfile userProfile = OauthUserProfileProvider.getUserProfile(tokenResponse,
 			oauthProvider, providerName);
 
+		// 조회한 사용자 정보를 기반으로 Member 엔티티 생성 및 DB에 저장
 		Member member = memberService.saveOrUpdate(userProfile);
 
-		JwtToken token = tokenProvider.createJwtToken(member.getId(), member.getName());
+		// 사용자 정보를 기반으로 JWT token 생성
+		JwtToken token = tokenProvider.createJwtToken(member.getUserId(), member.getName());
+
+		// RedisDB 에 JWT refresh Token 저장
+		redisService.setValue(String.valueOf(member.getId()), token.getRefreshToken());
 
 		return LoginResponseDto.builder()
 			.userId(member.getId())
 			.imgUrl(member.getImgUrl())
 			.accessToken(token.getAccessToken())
 			.refreshToken(token.getRefreshToken())
+			.build();
+	}
+
+	@Transactional
+	public TokenReissueResponseDto reissue(TokenReissueRequestDto requestDto) {
+		String accessToken = requestDto.getAccessToken();
+		String refreshToken = requestDto.getRefreshToken();
+
+		// JWT 토큰의 유효성 검사
+		if (!tokenProvider.validateToken(accessToken) || !tokenProvider.validateToken(refreshToken)) {
+			throw new RuntimeException("Token 이 유효하지 않습니다.");
+		}
+
+		// JWT access Token 에서 Member id 가져오기
+		String userId = (String) tokenProvider.parseClaims(accessToken).get("id");
+		Member member = memberService.findByUserId(userId);
+		Long id = member.getId();
+
+		// Member id 기반으로 RedisDB에 저장되어 있는 JWT refresh token 가져오기
+		String refreshTokenValue = Optional.ofNullable(redisService.getValue(String.valueOf(id)))
+				.orElseThrow(() -> new RuntimeException("로그아웃된 사용자 입니다."));
+
+		// refresh Token 검증
+		if (!refreshToken.equals(refreshTokenValue)) {
+			throw new RuntimeException("토큰의 정보가 일치하지 않습니다.");
+		}
+
+		// 새로운 토큰 생성
+		JwtToken newToken = tokenProvider.createJwtToken(member.getUserId(), member.getName());
+
+		return TokenReissueResponseDto.builder()
+			.accessToken(newToken.getAccessToken())
+			.refreshToken(refreshToken)
 			.build();
 	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/Member.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/Member.java
@@ -7,12 +7,16 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member {
 
@@ -47,5 +51,11 @@ public class Member {
 		this.email = email;
 		this.imgUrl = imgUrl;
 		return this;
+	}
+
+	public static Member of(Long memberId) {
+		return Member.builder()
+			.id(memberId)
+			.build();
 	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/MemberRepository.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.team09.issue_tracker.member;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByUserId(String userId);
+
+	long countByIdIn(List<Long> memberIds);
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/MemberService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/MemberService.java
@@ -18,4 +18,13 @@ public class MemberService {
 		return memberRepository.save(resultMember);
 	}
 
+	public Long findIdFromUserId(String userId) {
+		Member member = findByUserId(userId);
+		return member.getId();
+	}
+
+	public Member findByUserId(String userId) {
+		return memberRepository.findByUserId(userId)
+			.orElseThrow(() -> new RuntimeException("userId에 해당하는 멤버가 존재하지 않습니다!!"));
+	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/MemberService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.team09.issue_tracker.member;
 
 import com.team09.issue_tracker.login.oauth.user.OauthUserProfile;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,4 +19,9 @@ public class MemberService {
 		return memberRepository.save(resultMember);
 	}
 
+	public boolean validateMemberIds(List<Long> memberIds){
+		long countOfMemberFromDb = memberRepository.countByIdIn(memberIds);
+
+		return countOfMemberFromDb == memberIds.size();
+	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/MemberType.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/MemberType.java
@@ -1,6 +1,15 @@
 package com.team09.issue_tracker.member;
 
+import java.util.Arrays;
+
 public enum MemberType {
 
 	GITHUB, APPLE, GENERAL;
+
+	public static MemberType getEnum(String value) {
+		return Arrays.stream(MemberType.values())
+			.filter(memberType -> memberType.name().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("지원하지 않는 Provider 입니다!"));
+	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/member/MemberType.java
+++ b/BE/src/main/java/com/team09/issue_tracker/member/MemberType.java
@@ -2,5 +2,5 @@ package com.team09.issue_tracker.member;
 
 public enum MemberType {
 
-	github,apple,general;
+	GITHUB, APPLE, GENERAL;
 }

--- a/BE/src/main/java/com/team09/issue_tracker/milestone/Milestone.java
+++ b/BE/src/main/java/com/team09/issue_tracker/milestone/Milestone.java
@@ -10,7 +10,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Milestone {
 
@@ -31,5 +38,11 @@ public class Milestone {
 
 	public String getTitle() {
 		return title;
+	}
+
+	public static Milestone of(Long mileStoneId) {
+		return Milestone.builder()
+			.id(mileStoneId)
+			.build();
 	}
 }

--- a/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneRepository.java
+++ b/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneRepository.java
@@ -1,0 +1,10 @@
+package com.team09.issue_tracker.milestone;
+
+import com.team09.issue_tracker.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
+
+	long countByIdAndWriter(Long id , Member writer);
+
+}

--- a/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneService.java
@@ -1,0 +1,24 @@
+package com.team09.issue_tracker.milestone;
+
+import com.team09.issue_tracker.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MilestoneService {
+
+	private final MilestoneRepository milestoneRepository;
+
+	@Transactional(readOnly = true)
+	public boolean isMyMilestone(Long milestoneId, Long memberId) {
+		Member member = Member.of(memberId);
+		long countOfMyMilestone = milestoneRepository.countByIdAndWriter(milestoneId, member);
+
+		if (countOfMyMilestone == 1) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneService.java
+++ b/BE/src/main/java/com/team09/issue_tracker/milestone/MilestoneService.java
@@ -16,9 +16,6 @@ public class MilestoneService {
 		Member member = Member.of(memberId);
 		long countOfMyMilestone = milestoneRepository.countByIdAndWriter(milestoneId, member);
 
-		if (countOfMyMilestone == 1) {
-			return true;
-		}
-		return false;
+		return countOfMyMilestone == 1;
 	}
 }

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
           charSet: UTF-8
         dialect: org.hibernate.dialect.MySQL8Dialect
         open-in-view: false
+  redis:
+    host: localhost
+    port: 6379
 ---
 # log-group
 spring:

--- a/BE/src/test/java/com/team09/issue_tracker/issue/IssueCreateRepositoryTest.java
+++ b/BE/src/test/java/com/team09/issue_tracker/issue/IssueCreateRepositoryTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.team09.issue_tracker.issue.domain.Issue;
 import com.team09.issue_tracker.issue.dto.IssueSaveRequestDto;
-import org.assertj.core.api.Assertions;
+import com.team09.issue_tracker.milestone.Milestone;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,24 +26,29 @@ public class IssueCreateRepositoryTest {
 	IssueRepository issueRepository;
 	final Long MEMBER_ID = 1L;
 
-	@DisplayName("필수 요소만 가진 이슈")
-	@Test
-	void saveOnlyMandatory() {
-		//given
-		IssueSaveRequestDto issueSaveRequestDto = IssueSaveRequestDto.builder()
-			.title("제목")
-			.content("내용")
-			.build();
-		boolean isOpened = true;
-		Issue issue = Issue.fromForMandatory(issueSaveRequestDto, isOpened, MEMBER_ID);
+	/** TODO : repository 테스트인데, 일부 서비스 테스트 요소가 들어가 있는 것 같다.
+	 		 왜냐면, request parameter를 엔티티로 변환하는 과정이 들어가 있는 것 같다.
+	 **/
+//	@DisplayName("필수 요소만 가진 이슈")
+//	@Test
+//	void saveOnlyMandatory() {
+//		//given
+//		IssueSaveRequestDto issueSaveRequestDto = IssueSaveRequestDto.builder()
+//			.title("제목")
+//			.content("내용")
+//			.build();
+//		boolean isOpened = true;
+//		Issue issue = Issue.from(issueSaveRequestDto, isOpened, MEMBER_ID);
+//
+//		//when
+//		Issue savedIssue = issueRepository.save(issue);
+//
+//		//then
+//		assertAll(
+//			() -> assertThat(savedIssue.getTitle()).isEqualTo("제목"),
+//			() -> assertThat(savedIssue.getContent()).isEqualTo("내용")
+//		);
+//	}
+	
 
-		//when
-		Issue savedIssue = issueRepository.save(issue);
-
-		//then
-		assertAll(
-			() -> assertThat(savedIssue.getTitle()).isEqualTo("제목"),
-			() -> assertThat(savedIssue.getContent()).isEqualTo("내용")
-		);
-	}
 }

--- a/BE/src/test/java/com/team09/issue_tracker/issue/IssueCreateRepositoryTest.java
+++ b/BE/src/test/java/com/team09/issue_tracker/issue/IssueCreateRepositoryTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("IssueRepository 이슈 생성")
-@Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 public class IssueCreateRepositoryTest {

--- a/BE/src/test/java/com/team09/issue_tracker/issue/IssueSelectRepositoryTest.java
+++ b/BE/src/test/java/com/team09/issue_tracker/issue/IssueSelectRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("IssueRepository 이슈 조회")
-@Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class IssueSelectRepositoryTest {

--- a/BE/src/test/java/com/team09/issue_tracker/issue/studyofjpa/QueryMethodTest.java
+++ b/BE/src/test/java/com/team09/issue_tracker/issue/studyofjpa/QueryMethodTest.java
@@ -1,0 +1,108 @@
+package com.team09.issue_tracker.issue.studyofjpa;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.team09.issue_tracker.issue.IssueRepository;
+import com.team09.issue_tracker.issue.domain.Issue;
+import com.team09.issue_tracker.label.LabelRepository;
+import com.team09.issue_tracker.member.Member;
+import com.team09.issue_tracker.milestone.Milestone;
+import com.team09.issue_tracker.milestone.MilestoneRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("메서드 쿼리 학습테스트")
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+public class QueryMethodTest {
+
+	@Autowired
+	IssueRepository issueRepository;
+	@Autowired
+	MilestoneRepository milestoneRepository;
+	@Autowired
+	LabelRepository labelRepository;
+
+	final Long MEMBER_ID = 1L;
+	final Long MILESTONE_ID = 1L;
+
+	@Test
+	@DisplayName("Property Expressions 테스트")
+	void findByMilestone() {
+		//given
+		Milestone milestone = Milestone.of(1L);
+
+		//when
+		Stream<Issue> findIssue = issueRepository.findByMilestone(milestone);
+
+		//then
+		assertThat(findIssue.anyMatch(Objects::nonNull)).isTrue();
+	}
+
+	@Test
+	@DisplayName("count 쿼리메서드 테스트")
+	void countByMilestoneIdAndMemberId() {
+		//given
+		Member member = Member.of(MEMBER_ID);
+
+		//when
+		long count = milestoneRepository.countByIdAndWriter(MILESTONE_ID, member);
+
+		//then
+		assertThat(count).isEqualTo(1);
+	}
+	
+	@Test
+	@DisplayName("existByIdsAndMemberId()")
+	void existByIdsAndMemberId() {
+		//given
+		Set<Long> labelIds = Set.of(1L,2L,3L);
+
+		//when
+		boolean existMyLabels = labelRepository.existsByIdInAndMemberId(labelIds, MEMBER_ID);
+
+		//then
+		assertThat(existMyLabels).isFalse();
+	}
+
+	@Test
+	@DisplayName("existsByIdAndMemberId()")
+	void existsByIdAndMemberId() {
+		//given
+		Long labelId = 3L;
+
+		//when
+		boolean existMyLabels = labelRepository.existsByIdAndMemberId(labelId, MEMBER_ID);
+
+		//then
+		assertThat(existMyLabels).isFalse();
+	}
+	
+	@Test
+	void countByIdInAndMemberId() {
+		//given
+		List<Long> labelIds = List.of(1L,2L,3L);
+
+		//when
+		long labelCount = labelRepository.countByIdInAndMemberId(labelIds, MEMBER_ID);
+
+		//then
+		Assertions.assertAll(
+			() -> assertThat(labelCount).isNotEqualTo(3),
+			() -> assertThat(labelCount).isEqualTo(2),
+			() -> assertThat(labelCount).isNotEqualTo(labelIds.size())
+		);
+	}
+}

--- a/BE/src/test/java/com/team09/issue_tracker/issue/studyofjpa/QueryMethodTest.java
+++ b/BE/src/test/java/com/team09/issue_tracker/issue/studyofjpa/QueryMethodTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("메서드 쿼리 학습테스트")
-@Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 public class QueryMethodTest {


### PR DESCRIPTION
안녕하세요 `프레디`!
`테리, 벅픽` 입니다. 2주차 1번째 PR 입니다.
세심한 리뷰 항상 감사드립니다!! 😀


리뷰 받고 싶은 부분은 코멘트로 추가하였습니다!
감사합니다!


### ERD 및 API docs

<details>
<summary> ERD </summary>
    
![image](https://user-images.githubusercontent.com/91416897/174514679-dcae6a60-c8a8-4284-9160-c3575af76cfe.png)
    
</details>

<details>
<summary> API docs </summary>
    
https://documenter.getpostman.com/view/20452796/UzBiNobv
    
</details>

### 작업 내용


<summary> ✅  Issue 생성 API 작성 </summary>

- 유의해서 개발한 부분 : 검증 로직
    - Issue 생성을 위해 연관된  마일스톤, 레이블, 할당자 를  request Body에서 가져와 DB에 저장합니다. 
    - DB 저장 전에 연관된 마일스톤, 레이블, 할당자 가 실제 존재하며,  이슈 생성자가 생성한 정보인지 확인하는 검증 로직을 작성했습니다. 해당 검증로직은 고민하다가 `IssueValidateService` 에 작성하였습니다.
- 🧡 `리뷰 받고 싶은 부분`    
    - 로직을 짜는 것이 익숙하지 않고 어렵습니다.  소소하더라도 `로직 구현`에 대해 리뷰해 주신다면 많은 도움이 될 것 같습니다. 





<summary> ✅ Login API 마무리 </summary>
    
- 로그인 관련하여 전체 흐름도는 다음과 같습니다.
    ![image](https://user-images.githubusercontent.com/91416897/174982228-48e8dd2c-992d-4c01-bfea-5fac8cc95cfb.png)
    
- Spring Filter를 통해 검증이 필요한 URL에 대하여 JWT access token을 검증하는 로직을 추가하였습니다.    

- RedisDB를 통한 refresh 토큰 저장 기능을 추가하였습니다.

- 만약 프론트에서 만료된 access token으로 접근시에, 예외를 응답합니다. 아직 예외처리 핸들러는 추가하지 않아, 스프링 기본 설정 예외가 반환됩니다. 예외처리 핸들러는 추후 추가할 예정입니다.
    
- 프론트에서는 access token과 refresh token을 요청 바디에 넣어 토큰 갱신 요청을 보냅니다. 서버에서는 RedisDB에 저장되어 있는 refresh token을 바탕으로 검증을 하고, 새롭게 생성한 access token을 반환합니다.
    - refresh token의 경우 RedisDB에 저장될 때, 토큰의 만료시간만큼을 DB상의 만료시간으로 설정합니다.
    
    
