### PR TITLE
[Team-03] [Android] [2주차 2번째 PR ]  이슈 리스트 롱클릭시 체크박스 등장 로직 구현,   이슈 디테일 화면 더보기 버튼 클릭시 DialogFragment 구현

### DIFF
--- a/Android/app/src/main/java/com/example/issue_tracker/domain/model/Comment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/domain/model/Comment.kt
@@ -1,15 +1,10 @@
 package com.example.issue_tracker.domain.model
 
-sealed class Comment
-
-data class MyComment(
+data class Comment(
     val writer: User,
     val time: String,
+    val editable: Boolean,
     val content: String
-) : Comment()
+)
 
-data class OtherComment(
-    val writer: User,
-    val time: String,
-    val content: String
-) : Comment()
+

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailAdapter.kt
@@ -6,8 +6,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.issue_tracker.databinding.ItemCommentMyselfBinding
 import com.example.issue_tracker.databinding.ItemCommentOtherBinding
 import com.example.issue_tracker.domain.model.Comment
-import com.example.issue_tracker.domain.model.MyComment
-import com.example.issue_tracker.domain.model.OtherComment
 import com.example.issue_tracker.ui.common.getTimeDiff
 
 
@@ -28,12 +26,10 @@ class IssueDetailAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is MyCommentViewHolder -> {
-                val item = comments[position] as MyComment
-                holder.bind(item)
+                holder.bind(comments[position])
             }
             is OtherCommentViewHolder -> {
-                val item = comments[position] as OtherComment
-                holder.bind(item)
+                holder.bind(comments[position])
             }
 
         }
@@ -42,7 +38,7 @@ class IssueDetailAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     inner class MyCommentViewHolder(private val binding: ItemCommentMyselfBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(comment: MyComment) {
+        fun bind(comment: Comment) {
             binding.comment = comment
             binding.logTime = getTimeDiff(comment.time)
         }
@@ -50,15 +46,15 @@ class IssueDetailAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     inner class OtherCommentViewHolder(private val binding: ItemCommentOtherBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(comment: OtherComment) {
+        fun bind(comment: Comment) {
             binding.comment = comment
             binding.logTime = getTimeDiff(comment.time)
         }
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when (comments[position]) {
-            is MyComment -> VIEW_TYPE_MY_COMMENT
+        return when (comments[position].editable) {
+            true-> VIEW_TYPE_MY_COMMENT
             else -> VIEW_TYPE_OTHER_COMMENT
         }
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailFragment.kt
@@ -30,7 +30,12 @@ class IssueDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         issueID = requireArguments().getInt(Constants.ISSUE_ID_KEY)
         adapter = IssueDetailAdapter()
+        binding.id = issueID.toString()
         binding.rvIssueDetail.adapter = adapter
+        loadComments()
+    }
+
+    private fun loadComments(){
         viewModel.loadDetail(issueID)
         viewModel.issueDetail.observe(viewLifecycleOwner) {
             binding.tvIssueDetailTitle.text = it.title
@@ -46,4 +51,6 @@ class IssueDetailFragment : Fragment() {
             adapter.submitList(it.comment)
         }
     }
+
+
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailFragment.kt
@@ -33,6 +33,7 @@ class IssueDetailFragment : Fragment() {
         binding.id = issueID.toString()
         binding.rvIssueDetail.adapter = adapter
         loadComments()
+        switchEditMode()
     }
 
     private fun loadComments(){
@@ -52,5 +53,11 @@ class IssueDetailFragment : Fragment() {
         }
     }
 
+    private fun switchEditMode(){
+        binding.iBtnIssueDetailMore.setOnClickListener {
+            val dialog = IssueDetailMoreDialogFragment()
+            dialog.show(requireParentFragment().childFragmentManager, "more")
+        }
+    }
 
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailMoreDialogFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailMoreDialogFragment.kt
@@ -1,0 +1,35 @@
+package com.example.issue_tracker.ui.issue.detail
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import com.example.issue_tracker.R
+import com.example.issue_tracker.databinding.FragmentIssueDetailMoreDialogBinding
+
+class IssueDetailMoreDialogFragment : DialogFragment() {
+
+    private lateinit var binding: FragmentIssueDetailMoreDialogBinding
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_issue_detail_more_dialog, container, false)
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        dialog?.window?.setGravity(Gravity.BOTTOM)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.iBtnIssueDetailMoreClose.setOnClickListener {
+            dismiss()
+        }
+    }
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailViewModel.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/detail/IssueDetailViewModel.kt
@@ -17,9 +17,9 @@ class IssueDetailViewModel:ViewModel() {
 
     private fun makeDummyComments():List<Comment>{
         val comments = mutableListOf<Comment>()
-        comments.add(MyComment(User(1,"Sam","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22,14,10,3).toString(),"테스트 커멘트"))
-        comments.add(OtherComment(User(2,"Daniel","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22, 12,10,3).toString(),"테스트 커멘트"))
-        comments.add(OtherComment(User(2,"Daniel","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22,12,10,3).toString(),"테스트 커멘트"))
+        comments.add(Comment(User(1,"Sam","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22,14,10,3).toString(), true,"테스트 커멘트"))
+        comments.add(Comment(User(2,"Daniel","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22, 12,10,3).toString(),false,"테스트 커멘트"))
+        comments.add(Comment(User(2,"Daniel","https://images.unsplash.com/photo-1655057011043-158c48f3809d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHx0b3BpYy1mZWVkfDEyfHhqUFI0aGxrQkdBfHxlbnwwfHx8fA%3D%3D&auto=format&fit=crop&w=500&q=60"),LocalDateTime.of(2022,6,22,12,10,3).toString(),false,"테스트 커멘트"))
         return comments
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapter.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapter.kt
@@ -1,6 +1,8 @@
 package com.example.issue_tracker.ui.issue.home
 
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,20 +10,55 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.issue_tracker.databinding.ItemIssuesBinding
 import com.example.issue_tracker.domain.model.Issue
 
-class IssueAdapter(private val itemClick: (selectedIssueID: Int) -> Unit) :
+class IssueAdapter(
+    private val itemClick: (selectedIssueID: Int) -> Unit
+) :
     ListAdapter<Issue, IssueAdapter.ViewHolder>(IssueDiffUtil) {
+    var issueAdapterEventListener: IssueAdapterEventListener? = null
+    var isEditMode = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IssueAdapter.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return ViewHolder(ItemIssuesBinding.inflate(inflater, parent, false))
+        return ViewHolder(
+            ItemIssuesBinding.inflate(inflater, parent, false)
+        )
     }
 
-    inner class ViewHolder(private val binding: ItemIssuesBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-        fun bind(itemIssue: Issue, itemClick: (selectedIssueID: Int) -> Unit) {
-            binding.itemIssue = itemIssue
-            binding.root.setOnClickListener {
+    inner class ViewHolder(
+        private val binding: ItemIssuesBinding
+        ) : RecyclerView.ViewHolder(binding.root)
+    {
+        fun bind(
+            itemIssue: Issue,
+            itemClick: (selectedIssueID: Int) -> Unit
+        ) {
+            if (isEditMode) {
+                binding.cbIssueSelector.visibility = View.VISIBLE
+                binding.cbIssueSelector.isChecked = false
+            } else {
+                binding.cbIssueSelector.visibility = View.GONE
+            }
+
+            binding.clSwipeView.setOnClickListener {
                 itemClick.invoke(itemIssue.id)
+            }
+            binding.itemIssue = itemIssue
+
+            binding.clSwipeView.setOnLongClickListener {
+                issueAdapterEventListener?.switchToEditMode(itemIssue.id)
+                true
+            }
+
+            binding.cbIssueSelector.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    issueAdapterEventListener?.addInCheckList(itemIssue.id)
+                    binding.cbIssueSelector.setBackgroundColor(0xffF2F2F7.toInt())
+                    binding.cbIssueSelector.buttonTintList = ColorStateList.valueOf(0xff007AFF.toInt())
+                } else {
+                    issueAdapterEventListener?.deleteInCheckList(itemIssue.id)
+                    binding.cbIssueSelector.setBackgroundColor(0xffffffff.toInt())
+                    binding.cbIssueSelector.buttonTintList = ColorStateList.valueOf(0xffD5D5DB.toInt())
+                }
             }
         }
     }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapterEventListener.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueAdapterEventListener.kt
@@ -1,0 +1,11 @@
+package com.example.issue_tracker.ui.issue.home
+
+import com.example.issue_tracker.domain.model.Issue
+
+interface IssueAdapterEventListener {
+    fun updateIssueState(itemId: Int, boolean: Boolean)
+    fun switchToEditMode(itemId: Int)
+    fun addInCheckList(itemId: Int)
+    fun deleteInCheckList(itemId: Int)
+    fun getIntoDetail(issue: Issue)
+}

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeFragment.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeFragment.kt
@@ -26,6 +26,7 @@ import com.example.issue_tracker.common.Constants
 import com.example.issue_tracker.databinding.FragmentIssueHomeBinding
 import com.example.issue_tracker.domain.model.SpinnerType
 import com.example.issue_tracker.ui.HomeViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 class IssueHomeFragment : Fragment() {
@@ -61,20 +62,36 @@ class IssueHomeFragment : Fragment() {
         setSwitchToListModeFromFilterMode()
         setSwitchSearchMode()
         setSwitchToListModeFromSearchMode()
-
+        setDefaultFilterMenu()
+        setDefaultFilterSelection()
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch { loadStateList() }
-                launch { loadLabelList() }
-                launch { loadMileStoneList() }
-                launch { loadUserList() }
-                launch { loadIssueList() }
+                async { loadStateList() }
+                async { loadLabelList() }
+                async { loadMileStoneList() }
+                async { loadUserList() }
+                async { loadIssueList() }
             }
         }
 
         binding.etlSearch.setEndIconOnClickListener {
             //To do: Search 로직 (백엔드 API와 협의 필요)
         }
+    }
+
+    private fun setDefaultFilterMenu(){
+        val menuList = mutableListOf(getString(R.string.spinner_default))
+        setSpinner(menuList, SpinnerType.STATE)
+        setSpinner(menuList, SpinnerType.WRITER)
+        setSpinner(menuList, SpinnerType.LABEL)
+        setSpinner(menuList, SpinnerType.MILESTONE)
+    }
+
+    private fun setDefaultFilterSelection(){
+        binding.spinnerIssueState.setSelection(0)
+        binding.spinnerIssueMilestone.setSelection(0)
+        binding.spinnerIssueAssignee.setSelection(0)
+        binding.spinnerIssueLabel.setSelection(0)
     }
 
     private suspend fun loadIssueList() {
@@ -93,7 +110,6 @@ class IssueHomeFragment : Fragment() {
         }
 
     }
-
     private suspend fun loadUserList() {
         val userList = mutableListOf(getString(R.string.spinner_default))
         sharedViewModel.userList.collect {
@@ -106,6 +122,7 @@ class IssueHomeFragment : Fragment() {
 
     private suspend fun loadLabelList() {
         val labelList = mutableListOf(getString(R.string.spinner_default))
+        setSpinner(labelList, SpinnerType.LABEL)
         sharedViewModel.labelList.collect {
             it.forEach { label ->
                 labelList.add(label.title)
@@ -206,6 +223,5 @@ class IssueHomeFragment : Fragment() {
         super.onStop()
         changeStatusBarWhite()
     }
-
 
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeViewModel.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/IssueHomeViewModel.kt
@@ -10,8 +10,14 @@ class IssueHomeViewModel : ViewModel() {
     private val _stateList = MutableStateFlow<List<IssueState>>(listOf())
     val stateList: StateFlow<List<IssueState>> = _stateList
 
-    private val _issueList = MutableStateFlow<List<Issue>>(listOf())
+    private val _issueList = MutableStateFlow<MutableList<Issue>>(mutableListOf())
     val issueList: StateFlow<List<Issue>> = _issueList
+
+    private val _checkList = MutableStateFlow<MutableList<Int>>(mutableListOf())
+    val checkList: StateFlow<List<Int>> = _checkList
+
+    private val _closeIssueList = MutableStateFlow<MutableList<Issue>>(mutableListOf())
+    val closeIssueList: StateFlow<List<Issue>> = _closeIssueList
 
     init {
         initStateList()
@@ -19,14 +25,54 @@ class IssueHomeViewModel : ViewModel() {
     }
 
     private fun initStateList() {
-        _stateList.value = listOf(IssueState.OPEN, IssueState.WRITE_MYSELF, IssueState.ASSIGN_MYSELF, IssueState.WRITE_COMMENT, IssueState.CLOSE)
+        _stateList.value = listOf(
+            IssueState.OPEN,
+            IssueState.WRITE_MYSELF,
+            IssueState.ASSIGN_MYSELF,
+            IssueState.WRITE_COMMENT,
+            IssueState.CLOSE
+        )
     }
 
     private fun makeDummyIssueList() {
-        _issueList.value = listOf<Issue>(
+        _issueList.value = mutableListOf<Issue>(
             Issue(1, "마일스톤", "제목", "설명", "label"),
             Issue(2, "마스터즈 코스1", "이슈트래커1", "6월 13일에서 20일까지", "ABCDEF"),
             Issue(3, "마스터즈 코스2", "이슈트래커2", "7월 9일에서 12일까지", "asdfef")
         )
+    }
+
+    fun addCheckList(itemId: Int) {
+        _checkList.value.add(itemId)
+    }
+
+    fun removeCheckList(itemId: Int) {
+        _checkList.value.removeIf {
+            it == itemId
+        }
+    }
+
+    fun clearCheckList() {
+        _checkList.value.clear()
+    }
+
+    fun closeIssueList() {
+        for (i in 0 until _checkList.value.size) {
+            val str = _issueList.value.filter {
+                it.id == _checkList.value[i]
+            }
+            _issueList.value.removeIf {
+                it.id == checkList.value[i]
+            }
+            _closeIssueList.value.add(str[0])
+        }
+    }
+
+    fun removeIssueList() {
+        for (i in 0 until _checkList.value.size) {
+            _issueList.value.removeIf {
+                it.id == checkList.value[i]
+            }
+        }
     }
 }

--- a/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/ItemHelper.kt
+++ b/Android/app/src/main/java/com/example/issue_tracker/ui/issue/home/ItemHelper.kt
@@ -4,7 +4,7 @@ import android.graphics.Canvas
 import android.icu.lang.UCharacter.IndicPositionalCategory.LEFT
 import android.view.View
 import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.recyclerview.widget.ItemTouchHelper.*
+import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_SWIPE
 import androidx.recyclerview.widget.RecyclerView
 import com.example.issue_tracker.R
 
@@ -52,13 +52,6 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
                 isCurrentlyActive
             )  // newX 만큼 이동(고정 시 이동 위치/고정 해제 시 이동 위치 결정)
 
-            // 고정시킬 시 애니메이션 추가
-//            if (newX == -clamp) {
-//                getView(viewHolder).animate().translationX(-clamp).setDuration(100L).start()
-//                return
-//            }
-
-            currentDx = newX
             getDefaultUIUtil().onDraw(
                 c,
                 recyclerView,
@@ -74,7 +67,7 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
     private fun getView(viewHolder: RecyclerView.ViewHolder): View =
         viewHolder.itemView.findViewById(R.id.cl_swipe_view)
 
-    private fun getTag(viewHolder: RecyclerView.ViewHolder) : Boolean =
+    private fun getTag(viewHolder: RecyclerView.ViewHolder): Boolean =
         viewHolder.itemView.tag as? Boolean ?: false
 
 
@@ -82,17 +75,14 @@ class ItemHelper(private val issueAdapter: IssueAdapter) : ItemTouchHelper.Callb
         dX: Float,
         isClamped: Boolean,
         isCurrentlyActive: Boolean
-    ) : Float {
+    ): Float {
 
-        // 고정할 수 있으면
-        val newX = if (isClamped) {
-            // 현재 swipe 중이면 swipe되는 영역 제한
-            if (isCurrentlyActive) {
-                dX - clamp
-            }
-            else -clamp
-        }
-        else dX / 4
+        val newX =
+            if (isClamped) {
+                if (isCurrentlyActive) {
+                    dX - clamp
+                } else -clamp
+            } else dX / 4
 
         return newX
     }

--- a/Android/app/src/main/res/drawable/ic_close_black.xml
+++ b/Android/app/src/main/res/drawable/ic_close_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M1,20V6.7H0V0H20V6.7H19V20H1ZM3,18H17V7H3V18ZM2,5H18V2H2V5ZM7,12H13V10H7V12ZM3,18V7V18Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_delete_red.xml
+++ b/Android/app/src/main/res/drawable/ic_delete_red.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="18dp"
+    android:viewportWidth="16"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M1,18V3H0V1H5V0H11V1H16V3H15V18H1ZM3,16H13V3H3V16ZM5,14H7V5H5V14ZM9,14H11V5H9V14Z"
+      android:fillColor="#FF3B30"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_edit.xml
+++ b/Android/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M0,14.2525V18.0025H3.75L14.81,6.9425L11.06,3.1925L0,14.2525ZM17.71,4.0425C18.1,3.6525 18.1,3.0225 17.71,2.6325L15.37,0.2925C14.98,-0.0975 14.35,-0.0975 13.96,0.2925L12.13,2.1225L15.88,5.8725L17.71,4.0425Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_trash.xml
+++ b/Android/app/src/main/res/drawable/ic_trash.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="16.941177dp"
+    android:viewportHeight="18" android:viewportWidth="17"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#ffffff" android:pathData="M1.7485,18V3H0.7485V1H5.7485V0H11.7485V1H16.7485V3H15.7485V18H1.7485ZM3.7485,16H13.7485V3H3.7485V16ZM5.7485,14H7.7485V5H5.7485V14ZM9.7485,14H11.7485V5H9.7485V14Z"/>
+</vector>

--- a/Android/app/src/main/res/drawable/layout_width_border.xml
+++ b/Android/app/src/main/res/drawable/layout_width_border.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white"/>
+    <stroke android:width="2dp" android:color="@color/black" />
+
+
+</shape>

--- a/Android/app/src/main/res/layout/fragment_issue_detail.xml
+++ b/Android/app/src/main/res/layout/fragment_issue_detail.xml
@@ -4,8 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="writer"
+            type="String" />
+
+        <variable
+            name="id"
             type="String" />
 
         <variable
@@ -56,6 +61,16 @@
             app:layout_constraintStart_toStartOf="@id/tb_issue_detail"
             app:layout_constraintTop_toBottomOf="@id/tb_issue_detail" />
 
+
+        <TextView
+            android:id="@+id/tv_issue_detail_id"
+            style="@style/HeadLine5.Grey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="#2"
+            app:layout_constraintStart_toEndOf="@id/tv_issue_detail_title"
+            app:layout_constraintTop_toTopOf="@id/tv_issue_detail_title" />
+
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_issue_detail_open_state"
             style="@style/Subtitle2"
@@ -89,29 +104,29 @@
 
         <TextView
             android:id="@+id/tv_issue_detail_info"
+            time="@{time}"
+            userName="@{writer}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toEndOf="@id/btn_issue_detail_open_state"
-            app:layout_constraintTop_toTopOf="@id/btn_issue_detail_open_state"
-            app:layout_constraintBottom_toBottomOf="@id/btn_issue_detail_open_state"
             android:layout_marginStart="16dp"
-            userName="@{writer}"
-            time="@{time}"/>
+            app:layout_constraintBottom_toBottomOf="@id/btn_issue_detail_open_state"
+            app:layout_constraintStart_toEndOf="@id/btn_issue_detail_open_state"
+            app:layout_constraintTop_toTopOf="@id/btn_issue_detail_open_state" />
 
         <View
             android:id="@+id/divider_issue_detail"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_info"
             android:layout_marginTop="16dp"
-            android:background="@color/grey3" />
+            android:background="@color/grey3"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_info" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:layout_width="match_parent"
             android:id="@+id/rv_issue_detail"
+            android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_marginTop="16dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider_issue_detail"

--- a/Android/app/src/main/res/layout/fragment_issue_detail_more_dialog.xml
+++ b/Android/app/src/main/res/layout/fragment_issue_detail_more_dialog.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/layout_width_border"
+        android:paddingHorizontal="5dp"
+        android:paddingTop="20dp"
+        tools:context=".ui.issue.detail.IssueDetailMoreDialogFragment">
+
+
+        <TextView
+            android:id="@+id/tv_issue_detail_more_title"
+            style="@style/HeadLine5"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingEnd="240dp"
+            android:text="이슈 상세정보"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/iBtn_issue_detail_more_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_close"
+            android:layout_marginEnd="20dp"
+            android:paddingTop="3dp"
+            app:layout_constraintStart_toEndOf="@id/tv_issue_detail_more_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_issue_detail_more_title"
+            app:tint="@color/grey1"
+
+            />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_issue_detail_more_option"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/greyScale2"
+            android:layout_marginTop="10dp"
+            android:paddingHorizontal="10dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_title">
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_label_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="@string/issue_write_label_option_title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:textColor="@color/black"
+                android:text="Document"
+                app:layout_constraintBottom_toBottomOf="@id/tv_issue_detail_more_label_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_issue_detail_more_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_milestone_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="@string/issue_write_milestone_option_title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_milestone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:textColor="@color/black"
+                android:text="없음"
+                app:layout_constraintBottom_toBottomOf="@id/tv_issue_detail_more_milestone_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_label_title" />
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_assignee_title"
+                style="@style/Subtitle2.Grey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="16dp"
+                android:text="@string/issue_write_writer_opiton_title"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_milestone_title" />
+
+
+            <TextView
+                android:id="@+id/tv_issue_detail_more_assignee"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:textColor="@color/black"
+                android:text="없음"
+                app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_milestone_title" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <TextView
+            android:id="@+id/tv_issue_detail_more_edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/cl_issue_detail_more_option"
+            android:text="편집하기"
+            android:paddingStart="140dp"
+            android:padding="10dp"
+            android:elevation="10dp"
+            android:drawablePadding="10dp"
+            android:drawableStart="@drawable/ic_edit"
+            style="@style/Subtitle1.Black" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_edit"
+            app:layout_constraintBottom_toTopOf="@id/tv_issue_detail_more_close"
+            android:background="@color/grey3"
+            />
+
+        <TextView
+            android:id="@+id/tv_issue_detail_more_close"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_edit"
+            android:text="닫기"
+            android:paddingStart="165dp"
+            android:padding="10dp"
+            android:drawablePadding="10dp"
+            android:drawableStart="@drawable/ic_close_black"
+            style="@style/Subtitle1.Black" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_close"
+            app:layout_constraintBottom_toTopOf="@id/tv_issue_detail_more_delete"
+            android:background="@color/grey3"
+            />
+
+
+        <TextView
+            android:id="@+id/tv_issue_detail_more_delete"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_close"
+            android:text="삭제"
+            android:paddingStart="167dp"
+            android:padding="10dp"
+            android:drawablePadding="10dp"
+            android:drawableStart="@drawable/ic_delete_red"
+            style="@style/Subtitle1.Red" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_issue_detail_more_delete"
+            android:background="@color/grey3"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/fragment_issue_home.xml
+++ b/Android/app/src/main/res/layout/fragment_issue_home.xml
@@ -4,31 +4,32 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <variable
+            name="viewModel"
+            type="com.example.issue_tracker.ui.issue.home.IssueHomeViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.issue.home.IssueHomeFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_issue_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/cl_search"
             app:layout_constraintBottom_toBottomOf="parent"
-            tools:context=".ui.issue.home.IssueHomeFragment">
-
+            app:layout_constraintTop_toBottomOf="@id/cl_search">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_issue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/tb_issues"
-                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="56dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@layout/item_issues" />
-
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/tb_issues"
@@ -235,6 +236,67 @@
                 app:layout_constraintStart_toEndOf="@id/tv_filter_mileStone_title"
                 app:layout_constraintTop_toTopOf="@id/tv_filter_mileStone_title" />
 
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_issue_edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/skyBlue"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/btn_issue_edit_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_close"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_issue_count"
+                style="@style/HeadLine6.White"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="72dp"
+                android:height="24dp"
+                android:text="0"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btn_issue_remove"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="63.25dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_trash"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btn_issue_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:backgroundTint="@color/skyBlue"
+                android:padding="0dp"
+                android:src="@drawable/ic_issue_close"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/white" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Android/app/src/main/res/layout/item_comment_myself.xml
+++ b/Android/app/src/main/res/layout/item_comment_myself.xml
@@ -5,7 +5,7 @@
     <data>
         <variable
             name="comment"
-            type="com.example.issue_tracker.domain.model.MyComment" />
+            type="com.example.issue_tracker.domain.model.Comment" />
 
         <variable
             name="logTime"

--- a/Android/app/src/main/res/layout/item_comment_other.xml
+++ b/Android/app/src/main/res/layout/item_comment_other.xml
@@ -5,7 +5,7 @@
     <data>
         <variable
             name="comment"
-            type="com.example.issue_tracker.domain.model.OtherComment" />
+            type="com.example.issue_tracker.domain.model.Comment" />
 
         <variable
             name="logTime"

--- a/Android/app/src/main/res/layout/item_issues.xml
+++ b/Android/app/src/main/res/layout/item_issues.xml
@@ -7,6 +7,7 @@
         <variable
             name="itemIssue"
             type="com.example.issue_tracker.domain.model.Issue" />
+
     </data>
 
     <FrameLayout
@@ -57,29 +58,18 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_swipe_view"
             android:layout_width="match_parent"
-            android:background="@color/white"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:background="@color/white">
 
-            <LinearLayout
-                android:id="@+id/ll_check"
+            <CheckBox
+                android:id="@+id/cb_issue_selector"
                 android:layout_width="100dp"
-                app:layout_constraintLeft_toLeftOf="parent"
-                android:visibility="gone"
                 android:layout_height="match_parent"
-                android:layout_weight="3"
-
-                android:background="#CCD4FF"
-                android:gravity="center"
-                android:orientation="vertical">
-
-                <ImageButton
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:padding="0dp"
-                    android:src="@drawable/ic_check_on" />
-
-            </LinearLayout>
+                android:checked="false"
+                android:buttonTint="#D5D5DB"
+                android:layout_gravity="center_horizontal"
+                android:visibility="visible"
+                app:layout_constraintLeft_toLeftOf="parent" />
 
             <ImageView
                 android:id="@+id/iv_issue_milestone"
@@ -88,7 +78,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="10dp"
                 android:src="@drawable/ic_milestone"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="@color/grey6" />
 
@@ -98,9 +88,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="36dp"
                 android:layout_marginTop="10dp"
-                android:text="@string/item_milestone_text"
+                android:text="@{itemIssue.milestone}"
                 android:textColor="@color/grey2"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
@@ -109,9 +99,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
-                android:text="@string/item_title"
+                android:text="@{itemIssue.title}"
                 android:textStyle="bold"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/iv_issue_milestone" />
 
             <TextView
@@ -120,10 +110,10 @@
                 android:layout_height="20dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="2dp"
-                android:text="description"
+                android:text="@{itemIssue.description}"
                 android:textColor="@color/grey1"
                 android:textSize="14sp"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/tv_issue_title" />
 
             <TextView
@@ -135,9 +125,9 @@
                 android:layout_marginBottom="17dp"
                 android:background="@drawable/bg_label"
                 android:gravity="center"
-                android:text="Label"
+                android:text="@{itemIssue.label}"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toRightOf="@id/ll_check"
+                app:layout_constraintLeft_toRightOf="@id/cb_issue_selector"
                 app:layout_constraintTop_toBottomOf="@id/tv_issue_description" />
 
             <View

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -14,6 +14,7 @@
     <color name="light_skyBlue">#FFCCD4FF</color>
     <color name="selected_skyBlue">#FFC7EBFF</color>
     <color name="greyScale">#FFE5E5EA</color>
+    <color name="greyScale2">#FFF2F2F7</color>
     <color name="grey1">#FF8E8E93</color>
     <color name="grey2">#FF87878D</color>
     <color name="red">#FFFF3B30</color>

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -64,6 +64,10 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="Subtitle1.Red">
+        <item name="android:textColor">@color/red</item>
+    </style>
+
 
     //14px
 

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -20,6 +20,9 @@
         <item name="android:textSize">23sp</item>
     </style>
 
+    <style name="HeadLine5.Grey">
+        <item name="android:textColor">@color/grey1</item>
+    </style>
     //20px
 
     <style name="HeadLine6" parent="TextAppearance.MaterialComponents.Headline6" />


### PR DESCRIPTION
## 진행사항

- 지난 PR 리뷰 반영
    -  Comment 모델을 수정했습니다
    -  Spinner에  init 메뉴를 할당해주는 코드를 추가했습니다
    -  Spinner에 setSelection(0) 코드를 추가해주어 화면 이동후에 글자 색이 변하는지 문제를 해결했습니다
   
- 이슈 화면 
    - 아이템 롱클릭시 Gone 되어있던 CheckBox를 Visible로 보이도록 아이템 구현
    - 롱클릭시 기본ToolBar는 Gone, EditMode용 ConstraintLayout이 보이도록 구현
    - checkBox를 체크할경우 뷰모델의 _checkList에서 id를 넣고 뺴는 방법으로 관리
    - checkBox를 체크후 삭제버튼을 누를경우 _issueList에서 _checkList에 있는 id를 기반으로 _issueList에서 삭제
    - 그후 편집모드 종료, 편집모드 재 호출시 _checkList의 리스트 .clear 하도록함
    - checkBox를 체크후 클로즈 버튼을 누를경우 id를 기반으로 issueList에서 삭제하고 closeIssueList에 해당 아이템들을 넣도록 구현

- 이슈 디테일 화면
    -  상단 toolbar의 더보기 버튼 클릭시 DialogFragment가 show 되도록 구현
    -  Dialog의  window.gravity를 이용해 화면 하단에 보여지도록 구현
 
   
## 추후 진행사항
-  백엔드쪽에서 서버를 오픈하는 대로 api 작업을 하나씩 진행해 나갈것 같습니다
-  이슈화면에 적용한 편집모드를 라벨, 마일스톤 리스트 페이지에도 적용할 예정입니다
-  디테일 화면에서 코멘트 편집모드와   남이 작성한 코멘트에 이모티콘을 표현할 수 있는 부분을 진행할 예정입니다. 


## 결과
![res4](https://user-images.githubusercontent.com/58967292/175450255-562d4406-58be-4087-9a00-26534604e3af.gif)