### PR TITLE
[team-32][BE][산토리&포키] IssueTracker 4차 PR 

### DIFF
--- a/be/src/main/java/com/codesquad/issuetracker/auth/application/AuthService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/application/AuthService.java
@@ -1,11 +1,16 @@
 package com.codesquad.issuetracker.auth.application;
 
+import com.codesquad.issuetracker.auth.presentation.dto.AccessTokenDto;
+import com.codesquad.issuetracker.common.util.TokenParser;
 import com.codesquad.issuetracker.exception.domain.BusinessException;
 import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
 import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+
+@Transactional
 @Service
 public class AuthService {
 
@@ -29,4 +34,19 @@ public class AuthService {
         return userRepository.findById(userId)
                 .orElseThrow(()-> new BusinessException(UserExceptionType.NOT_FOUND));
     }
+
+    public AccessTokenDto refreshAccessToken(String authorization) {
+        String refreshToken = TokenParser.parseToken(authorization);
+
+        jwtProvider.validateJwtToken(refreshToken);
+
+        User user = findUser(refreshToken);
+        user.validateRefreshToken(refreshToken);
+
+        String accessToken = jwtProvider.createAccessToken(user.getId());
+
+        return new AccessTokenDto(accessToken);
+    }
+
+
 }

--- a/be/src/main/java/com/codesquad/issuetracker/auth/application/AuthService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/application/AuthService.java
@@ -7,8 +7,8 @@ import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
 import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 
 @Transactional
 @Service

--- a/be/src/main/java/com/codesquad/issuetracker/auth/application/JwtProvider.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/application/JwtProvider.java
@@ -15,7 +15,7 @@ public class JwtProvider {
 
     private static final int ACCESS_TOKEN_EXPIRES_MINUTE = 60;
     private static final int REFRESH_TOKEN_EXPIRES_WEEK = 60 * 24 * 14;
-    private static final String USER_ID = "userId";
+    public static final String USER_ID_CLAIM_KEY = "userId";
     private final Algorithm algorithm;
 
     public JwtProvider(@Value("${auth.jwt.secret_key}") String secretKey) {
@@ -26,7 +26,7 @@ public class JwtProvider {
         Date accessTokenExpiredDate = Date.from(Instant.now().plus(ACCESS_TOKEN_EXPIRES_MINUTE, ChronoUnit.MINUTES));
 
         return JWT.create()
-                .withClaim(USER_ID, userId)
+                .withClaim(USER_ID_CLAIM_KEY, userId)
                 .withExpiresAt(accessTokenExpiredDate)
                 .sign(algorithm);
     }
@@ -35,7 +35,7 @@ public class JwtProvider {
         Date accessTokenExpiredDate = Date.from(Instant.now().plus(REFRESH_TOKEN_EXPIRES_WEEK, ChronoUnit.MINUTES));
 
         return JWT.create()
-                .withClaim(USER_ID, userId)
+                .withClaim(USER_ID_CLAIM_KEY, userId)
                 .withExpiresAt(accessTokenExpiredDate)
                 .sign(algorithm);
     }

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/argumentresolver/AuthArgumentResolver.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/argumentresolver/AuthArgumentResolver.java
@@ -1,5 +1,8 @@
 package com.codesquad.issuetracker.auth.presentation.argumentresolver;
 
+import com.codesquad.issuetracker.auth.application.AuthService;
+import com.codesquad.issuetracker.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -7,8 +10,10 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+
 import javax.servlet.http.HttpServletRequest;
 
+@Slf4j
 @Component
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -16,9 +21,9 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     public boolean supportsParameter(MethodParameter parameter) {
 
         boolean hasAuth = parameter.hasParameterAnnotation(Auth.class);
-        boolean hasUser = com.codesquad.issuetracker.user.domain.User.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasUserId = Long.class.isAssignableFrom(parameter.getParameterType());
 
-        return hasAuth && hasUser;
+        return hasAuth && hasUserId;
     }
 
     @Override
@@ -26,6 +31,8 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        return request.getAttribute("user");
+        long userId =(long) request.getAttribute("userId");
+
+        return userId;
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/controller/AuthController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.codesquad.issuetracker.auth.presentation.controller;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.codesquad.issuetracker.auth.application.AuthService;
+import com.codesquad.issuetracker.auth.presentation.dto.AccessTokenDto;
+import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/auth/refresh")
+    public AccessTokenDto refresh(HttpServletRequest request) {
+        String refreshToken = request.getHeader("Authorization");
+        return authService.refreshAccessToken(refreshToken);
+    }
+
+    @ExceptionHandler(JWTVerificationException.class)
+    public ResponseEntity<String> handleJwtVerificationException(JWTVerificationException ex) {
+        AuthExceptionType type = AuthExceptionType.INVALID_REFRESH_TOKEN;
+        return ResponseEntity.status(type.getStatusCode()).body(type.getMessage());
+    }
+
+}

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/dto/AccessTokenDto.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/dto/AccessTokenDto.java
@@ -1,0 +1,15 @@
+package com.codesquad.issuetracker.auth.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccessTokenDto {
+
+    private String accessToken;
+
+    public AccessTokenDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
 
-    private final AuthService authService;
     private final JwtProvider jwtProvider;
 
     @Override
@@ -33,7 +32,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         String token = TokenParser.parseToken(authorization);
 
         try {
-            authService.validateToken(token);
+            jwtProvider.validateJwtToken(token);
         } catch (TokenExpiredException e) {
             e.printStackTrace();
             throw new BusinessException(AuthExceptionType.TOKEN_EXPIRED);
@@ -42,7 +41,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             throw new BusinessException(AuthExceptionType.INVALID_ACCESS_TOKEN);
         }
 
-        Long userId = jwtProvider.getClaimFromToken(token, "userId");
+        Long userId = jwtProvider.getClaimFromToken(token, JwtProvider.USER_ID_CLAIM_KEY);
         request.setAttribute("userId", userId);
         return true;
     }

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
@@ -8,6 +8,7 @@ import com.codesquad.issuetracker.auth.application.JwtProvider;
 import com.codesquad.issuetracker.common.util.TokenParser;
 import com.codesquad.issuetracker.exception.domain.BusinessException;
 import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
+import com.codesquad.issuetracker.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 public class AuthInterceptor implements HandlerInterceptor {
 
     private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -42,6 +44,8 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         Long userId = jwtProvider.getClaimFromToken(token, JwtProvider.USER_ID_CLAIM_KEY);
+        userService.doesExist(userId);
+
         request.setAttribute("userId", userId);
         return true;
     }

--- a/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
+++ b/be/src/main/java/com/codesquad/issuetracker/auth/presentation/interceptor/AuthInterceptor.java
@@ -4,10 +4,11 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.codesquad.issuetracker.auth.application.AuthService;
+import com.codesquad.issuetracker.auth.application.JwtProvider;
 import com.codesquad.issuetracker.common.util.TokenParser;
 import com.codesquad.issuetracker.exception.domain.BusinessException;
 import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
-import com.codesquad.issuetracker.user.domain.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -16,14 +17,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
 
     private final AuthService authService;
-
-    public AuthInterceptor(AuthService authService) {
-        this.authService = authService;
-    }
+    private final JwtProvider jwtProvider;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -43,11 +42,9 @@ public class AuthInterceptor implements HandlerInterceptor {
             throw new BusinessException(AuthExceptionType.INVALID_ACCESS_TOKEN);
         }
 
-        User user = authService.findUser(token);
-        request.setAttribute("user", user);
-
+        Long userId = jwtProvider.getClaimFromToken(token, "userId");
+        request.setAttribute("userId", userId);
         return true;
     }
-
 
 }

--- a/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
@@ -32,6 +32,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
+                        "/auth/**",
                         "/oauth/**",
                         "/login",
                         "/join/**",

--- a/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
@@ -2,6 +2,7 @@ package com.codesquad.issuetracker.common.config;
 
 import com.codesquad.issuetracker.auth.presentation.argumentresolver.AuthArgumentResolver;
 import com.codesquad.issuetracker.auth.presentation.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,16 +10,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class AuthConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
     private final AuthArgumentResolver authArgumentResolver;
-
-    public AuthConfig(AuthInterceptor authInterceptor, AuthArgumentResolver authArgumentResolver) {
-        this.authInterceptor = authInterceptor;
-        this.authArgumentResolver = authArgumentResolver;
-    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -36,6 +33,7 @@ public class AuthConfig implements WebMvcConfigurer {
                         "/oauth/**",
                         "/login",
                         "/join/**",
-                        "/error/**");
+                        "/error/**",
+                        "/favicon.ico");
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/config/AuthConfig.java
@@ -5,6 +5,7 @@ import com.codesquad.issuetracker.auth.presentation.interceptor.AuthInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -35,5 +36,12 @@ public class AuthConfig implements WebMvcConfigurer {
                         "/join/**",
                         "/error/**",
                         "/favicon.ico");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*");
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/common/util/PasswordEncryptor.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/util/PasswordEncryptor.java
@@ -1,0 +1,17 @@
+package com.codesquad.issuetracker.common.util;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class PasswordEncryptor {
+
+    private PasswordEncryptor() {
+    }
+
+    public static String hashPassword(String plainTextPassword) {
+        return BCrypt.hashpw(plainTextPassword, BCrypt.gensalt());
+    }
+
+    public static boolean checkPassword(String plainTextPassword, String hashedPassword) {
+        return BCrypt.checkpw(plainTextPassword, hashedPassword);
+    }
+}

--- a/be/src/main/java/com/codesquad/issuetracker/common/util/TokenParser.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/util/TokenParser.java
@@ -1,0 +1,28 @@
+package com.codesquad.issuetracker.common.util;
+
+import com.codesquad.issuetracker.exception.domain.BusinessException;
+import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
+
+public class TokenParser {
+
+    private static final String TOKEN_TYPE = "Bearer ";
+
+    public static String parseToken(String authorization) {
+        String token;
+        try {
+            validateAuthorizationHeader(authorization);
+            token = authorization.split(" ")[1].trim();
+        } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
+            e.printStackTrace();
+            throw new BusinessException(AuthExceptionType.TOKEN_NOT_FOUND);
+        }
+        return token;
+    }
+
+    private static void validateAuthorizationHeader(String authorization) {
+        if (authorization == null || !authorization.startsWith(TOKEN_TYPE)) {
+            throw new IllegalArgumentException("토큰의 형식이 잘못되었습니다.");
+        }
+    }
+
+}

--- a/be/src/main/java/com/codesquad/issuetracker/common/util/TokenParser.java
+++ b/be/src/main/java/com/codesquad/issuetracker/common/util/TokenParser.java
@@ -7,6 +7,9 @@ public class TokenParser {
 
     private static final String TOKEN_TYPE = "Bearer ";
 
+    private TokenParser() {
+    }
+
     public static String parseToken(String authorization) {
         String token;
         try {

--- a/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
@@ -2,24 +2,30 @@ package com.codesquad.issuetracker.exception.domain.type;
 
 import org.springframework.http.HttpStatus;
 
-public enum AuthExceptionType implements ExceptionType{
+public enum AuthExceptionType implements ExceptionType {
 
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "이 api에 접근하기 위해서는 Access 토큰이 필요합니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access 토큰입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh 토큰입니다.");
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH001", "이 api에 접근하기 위해서는 Access 토큰이 필요합니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH002", "액세스 토큰이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH003", "유효하지 않은 Access 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH004", "유효하지 않은 Refresh 토큰입니다.");
 
 
     private final HttpStatus statusCode;
+    private final String errorCode;
     private final String message;
 
-    AuthExceptionType(HttpStatus statusCode, String message) {
+    AuthExceptionType(HttpStatus statusCode, String errorCode, String message) {
         this.statusCode = statusCode;
+        this.errorCode = errorCode;
         this.message = message;
     }
 
     public HttpStatus getStatusCode() {
         return statusCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
     }
 
     public String getMessage() {

--- a/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
@@ -9,7 +9,6 @@ public enum AuthExceptionType implements ExceptionType {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH003", "유효하지 않은 Access 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH004", "유효하지 않은 Refresh 토큰입니다.");
 
-
     private final HttpStatus statusCode;
     private final String errorCode;
     private final String message;

--- a/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/AuthExceptionType.java
@@ -6,7 +6,9 @@ public enum AuthExceptionType implements ExceptionType{
 
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "이 api에 접근하기 위해서는 Access 토큰이 필요합니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다");
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh 토큰입니다.");
+
 
     private final HttpStatus statusCode;
     private final String message;

--- a/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/ExceptionType.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/ExceptionType.java
@@ -5,5 +5,6 @@ import org.springframework.http.HttpStatus;
 public interface ExceptionType {
 
     String getMessage();
+    String getErrorCode();
     HttpStatus getStatusCode();
 }

--- a/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/UserExceptionType.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/domain/type/UserExceptionType.java
@@ -4,20 +4,27 @@ import org.springframework.http.HttpStatus;
 
 public enum UserExceptionType implements ExceptionType {
 
-    NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-    DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "이미 가입된 아이디입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "USER001","유저를 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER002","비밀번호가 틀렸습니다."),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "USER003", "아이디나 비밀번호 형식이 잘못 되었습니다."),
+    DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "USER004","이미 가입된 아이디입니다.");
 
     private final HttpStatus statusCode;
+    private final String errorCode;
     private final String message;
 
-    UserExceptionType(HttpStatus statusCode, String message) {
+    UserExceptionType(HttpStatus statusCode, String errorCode, String message) {
         this.statusCode = statusCode;
+        this.errorCode = errorCode;
         this.message = message;
     }
 
     public HttpStatus getStatusCode() {
         return statusCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
     }
 
     public String getMessage() {

--- a/be/src/main/java/com/codesquad/issuetracker/exception/dto/ExceptionResponseDto.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/dto/ExceptionResponseDto.java
@@ -1,5 +1,6 @@
 package com.codesquad.issuetracker.exception.dto;
 
+import com.codesquad.issuetracker.exception.domain.type.ExceptionType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,11 +8,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ExceptionResponseDto {
 
-    private int code;
+    private String errorCode;
     private String message;
 
-    public ExceptionResponseDto(int code, String message) {
-        this.code = code;
+    public ExceptionResponseDto(String errorCode, String message) {
+        this.errorCode = errorCode;
         this.message = message;
+    }
+
+    public static ExceptionResponseDto from(ExceptionType exceptionType) {
+        return new ExceptionResponseDto(exceptionType.getErrorCode(), exceptionType.getMessage());
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/exception/handler/AuthExceptionHandler.java
+++ b/be/src/main/java/com/codesquad/issuetracker/exception/handler/AuthExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.codesquad.issuetracker.exception.handler;
 
 import com.codesquad.issuetracker.exception.domain.BusinessException;
-import org.springframework.http.HttpStatus;
+import com.codesquad.issuetracker.exception.domain.type.ExceptionType;
+import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
+import com.codesquad.issuetracker.exception.dto.ExceptionResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,12 +14,17 @@ import javax.servlet.http.HttpServletRequest;
 @RestControllerAdvice
 public class AuthExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> exceptionHandler(HttpServletRequest request, MethodArgumentNotValidException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("아이디나 비밀번호 형식이 잘못 되었습니다.");
+    public ResponseEntity<ExceptionResponseDto> exceptionHandler(HttpServletRequest request, MethodArgumentNotValidException exception) {
+        UserExceptionType exceptionType = UserExceptionType.INVALID_FORMAT;
+        return createResponseEntity(exceptionType);
     }
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<String> handleBusinessException(HttpServletRequest request, BusinessException exception) {
-        return ResponseEntity.status(exception.getExceptionType().getStatusCode()).body(exception.getMessage());
+    public ResponseEntity<ExceptionResponseDto> handleBusinessException(HttpServletRequest request, BusinessException exception) {
+        return createResponseEntity(exception.getExceptionType());
+    }
+
+    private ResponseEntity<ExceptionResponseDto> createResponseEntity(ExceptionType exceptionType) {
+        return ResponseEntity.status(exceptionType.getStatusCode()).body(ExceptionResponseDto.from(exceptionType));
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
@@ -31,4 +31,9 @@ public class BasicLoginService {
 
         return new LoginResponseDto(accessToken, refreshToken);
     }
+
+    public void logout(User user) {
+        user.expireRefreshToken();
+        userService.save(user);
+    }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
@@ -33,7 +33,7 @@ public class BasicLoginService {
     }
 
     public void logout(long userId) {
-        User user = userService.findById(userId).get();
+        User user = userService.findById(userId);
 
         user.expireRefreshToken();
     }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/BasicLoginService.java
@@ -32,8 +32,9 @@ public class BasicLoginService {
         return new LoginResponseDto(accessToken, refreshToken);
     }
 
-    public void logout(User user) {
+    public void logout(long userId) {
+        User user = userService.findById(userId).get();
+
         user.expireRefreshToken();
-        userService.save(user);
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
@@ -45,8 +45,9 @@ public class UserService {
         return userRepository.existsByUsername(username);
     }
 
-    public Optional<User> findById(long userId) {
-        return userRepository.findById(userId);
+    public User findById(long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(()-> new BusinessException(UserExceptionType.NOT_FOUND));
     }
 
     public Optional<User> findByUsername(String username) {

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
@@ -5,6 +5,7 @@ import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
 import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.domain.UserRepository;
 import com.codesquad.issuetracker.user.presentation.dto.UserJoinRequestDto;
+import com.codesquad.issuetracker.user.presentation.dto.UserResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -47,7 +48,7 @@ public class UserService {
 
     public User findById(long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(()-> new BusinessException(UserExceptionType.NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(UserExceptionType.NOT_FOUND));
     }
 
     public Optional<User> findByUsername(String username) {
@@ -60,4 +61,8 @@ public class UserService {
         }
     }
 
+    public UserResponseDto findUserInfo(long userId) {
+        return UserResponseDto.from(findById(userId));
+
+    }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
@@ -22,6 +22,10 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
+    public void save(User user) {
+        userRepository.save(user);
+    }
+
     public User join(UserJoinRequestDto userJoinRequestDto) {
 
         if (isDuplicatedUsername(userJoinRequestDto.getUsername())) {
@@ -44,4 +48,6 @@ public class UserService {
     public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
     }
+
+
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
@@ -54,5 +54,10 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
+    public void doesExist(long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(UserExceptionType.NOT_FOUND);
+        }
+    }
 
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/application/UserService.java
@@ -45,6 +45,10 @@ public class UserService {
         return userRepository.existsByUsername(username);
     }
 
+    public Optional<User> findById(long userId) {
+        return userRepository.findById(userId);
+    }
+
     public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
     }

--- a/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.codesquad.issuetracker.user.domain;
 
+import com.codesquad.issuetracker.common.util.PasswordEncryptor;
 import com.codesquad.issuetracker.exception.domain.BusinessException;
 import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
 import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
@@ -30,13 +31,13 @@ public class User {
     public User(String username, String name, String password, String profileImage, LoginType loginType) {
         this.username = username;
         this.name = name;
-        this.password = hashPassword(password);
+        this.password = PasswordEncryptor.hashPassword(password);
         this.profileImage = profileImage;
         this.loginType = loginType;
     }
 
     public void validatePassword(String plainTextPassword) {
-        if (!checkPassword(plainTextPassword, password)) {
+        if (!PasswordEncryptor.checkPassword(plainTextPassword, password)) {
             throw new BusinessException(UserExceptionType.INVALID_PASSWORD);
         }
     }
@@ -45,13 +46,6 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
-    private String hashPassword(String plainTextPassword) {
-        return BCrypt.hashpw(plainTextPassword, BCrypt.gensalt());
-    }
-
-    private boolean checkPassword(String plainTextPassword, String hashedPassword) {
-        return BCrypt.checkpw(plainTextPassword, hashedPassword);
-    }
 
     public void validateRefreshToken(String refreshToken) {
         if (!this.refreshToken.equals(refreshToken)) {

--- a/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.codesquad.issuetracker.user.domain;
 
 import com.codesquad.issuetracker.exception.domain.BusinessException;
+import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
 import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -52,6 +53,12 @@ public class User {
 
     private boolean checkPassword(String plainTextPassword, String hashedPassword) {
         return BCrypt.checkpw(plainTextPassword, hashedPassword);
+    }
+
+    public void validateRefreshToken(String refreshToken) {
+        if (!this.refreshToken.equals(refreshToken)) {
+            throw new BusinessException(AuthExceptionType.INVALID_REFRESH_TOKEN);
+        }
     }
 }
 

--- a/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
@@ -60,6 +60,10 @@ public class User {
             throw new BusinessException(AuthExceptionType.INVALID_REFRESH_TOKEN);
         }
     }
+
+    public void expireRefreshToken() {
+        this.refreshToken = "";
+    }
 }
 
 

--- a/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/domain/User.java
@@ -5,13 +5,11 @@ import com.codesquad.issuetracker.exception.domain.type.AuthExceptionType;
 import com.codesquad.issuetracker.exception.domain.type.UserExceptionType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.mindrot.jbcrypt.BCrypt;
 
 import javax.persistence.*;
 
 @Getter
-@ToString
 @NoArgsConstructor
 @Entity
 public class User {

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
@@ -30,8 +30,9 @@ public class LoginController {
 
     @Operation(summary = "Github 로그인 화면으로 Redirect 하기", description = "Github 로그인 페이지로 이동합니다.")
     @GetMapping("/oauth/github/login")
-    public ResponseEntity<Void> loginByGithub() throws URISyntaxException {
-        return ResponseEntity.status(HttpStatus.FOUND).location(new URI(githubRedirectUrl)).build();
+    public ResponseEntity<String> loginByGithub() throws URISyntaxException {
+        return ResponseEntity.ok()
+                .body(githubRedirectUrl);
     }
 
     @Operation(summary = "Github 로그인 처리하기", description = "Github Authorization code 를 받아서 로그인을 완료합니다.")

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
@@ -3,7 +3,6 @@ package com.codesquad.issuetracker.user.presentation.controller;
 import com.codesquad.issuetracker.auth.presentation.argumentresolver.Auth;
 import com.codesquad.issuetracker.user.application.BasicLoginService;
 import com.codesquad.issuetracker.user.application.OAuthLoginService;
-import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.presentation.dto.LoginResponseDto;
 import com.codesquad.issuetracker.user.presentation.dto.UserLoginRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -78,8 +77,8 @@ public class LoginController {
 
     @Operation(summary = "유저 로그아웃하기", description = "사용자의 로그아웃을 처리합니다.")
     @GetMapping("/logout")
-    public void logout(@Auth User user) {
-        basicLoginService.logout(user);
+    public void logout(@Auth Long userId) {
+        basicLoginService.logout(userId);
     }
 
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
@@ -30,9 +30,8 @@ public class LoginController {
 
     @Operation(summary = "Github 로그인 화면으로 Redirect 하기", description = "Github 로그인 페이지로 이동합니다.")
     @GetMapping("/oauth/github/login")
-    public ResponseEntity<String> loginByGithub() throws URISyntaxException {
-        return ResponseEntity.ok()
-                .body(githubRedirectUrl);
+    public ResponseEntity<String> loginByGithub() {
+        return ResponseEntity.ok().body(githubRedirectUrl);
     }
 
     @Operation(summary = "Github 로그인 처리하기", description = "Github Authorization code 를 받아서 로그인을 완료합니다.")

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
@@ -6,6 +6,7 @@ import com.codesquad.issuetracker.user.application.OAuthLoginService;
 import com.codesquad.issuetracker.user.presentation.dto.LoginResponseDto;
 import com.codesquad.issuetracker.user.presentation.dto.UserLoginRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -16,32 +17,16 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 public class LoginController {
 
     private final OAuthLoginService oAuthLoginService;
     private final BasicLoginService basicLoginService;
-    private final String redirectUrl;
-    private final String githubRedirectUrl;
-    private final String googleRedirectUrl;
-
-    public LoginController(
-            @Value("${oauth.redirect_url}") String redirectUrl,
-            @Value("${oauth.github.client_id}") String githubClientId,
-            @Value("${oauth.google.client_id}") String googleClientId,
-            OAuthLoginService oAuthLoginService,
-            BasicLoginService basicLoginService) {
-        this.oAuthLoginService = oAuthLoginService;
-        this.basicLoginService = basicLoginService;
-        this.redirectUrl = redirectUrl;
-        githubRedirectUrl =
-                "https://github.com/login/oauth/authorize?client_id=" + githubClientId + "&scope=user:email";
-        googleRedirectUrl =
-                "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + googleClientId
-                        + "&redirect_uri=" + redirectUrl + "/oauth/google/callback&"
-                        + "response_type=code&"
-                        + "scope=profile email";
-    }
+    @Value("${oauth.github.redirect_url}")
+    private String githubRedirectUrl;
+    @Value("${oauth.google.redirect_url}")
+    private String googleRedirectUrl;
 
     @Operation(summary = "Github 로그인 화면으로 Redirect 하기", description = "Github 로그인 페이지로 이동합니다.")
     @GetMapping("/oauth/github/login")

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/LoginController.java
@@ -1,7 +1,9 @@
 package com.codesquad.issuetracker.user.presentation.controller;
 
+import com.codesquad.issuetracker.auth.presentation.argumentresolver.Auth;
 import com.codesquad.issuetracker.user.application.BasicLoginService;
 import com.codesquad.issuetracker.user.application.OAuthLoginService;
+import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.presentation.dto.LoginResponseDto;
 import com.codesquad.issuetracker.user.presentation.dto.UserLoginRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -73,4 +75,11 @@ public class LoginController {
     public LoginResponseDto login(@RequestBody UserLoginRequestDto userLoginRequestDto) {
         return basicLoginService.login(userLoginRequestDto);
     }
+
+    @Operation(summary = "유저 로그아웃하기", description = "사용자의 로그아웃을 처리합니다.")
+    @GetMapping("/logout")
+    public void logout(@Auth User user) {
+        basicLoginService.logout(user);
+    }
+
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/UserController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.codesquad.issuetracker.user.presentation.controller;
 
+import com.codesquad.issuetracker.auth.presentation.argumentresolver.Auth;
 import com.codesquad.issuetracker.user.application.UserService;
 import com.codesquad.issuetracker.user.domain.LoginType;
 import com.codesquad.issuetracker.user.presentation.dto.UserJoinRequestDto;
+import com.codesquad.issuetracker.user.presentation.dto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +35,11 @@ public class UserController {
     @PostMapping("/join/checkId")
     public ResponseEntity<Boolean> checkDuplicateId(@RequestBody String userId) {
         return ResponseEntity.ok().body(userService.isDuplicatedUsername(userId));
+    }
+
+    @Operation(summary = "유저 정보 조회하기", description = "유저의 정보를 조회합니다.")
+    @GetMapping("/info")
+    public ResponseEntity<UserResponseDto> getUserInfo(@Auth Long userId) {
+        return ResponseEntity.ok().body(userService.findUserInfo(userId));
     }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/user/presentation/dto/UserResponseDto.java
+++ b/be/src/main/java/com/codesquad/issuetracker/user/presentation/dto/UserResponseDto.java
@@ -1,0 +1,26 @@
+package com.codesquad.issuetracker.user.presentation.dto;
+
+import com.codesquad.issuetracker.user.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserResponseDto {
+
+    private long id;
+    private String username;
+    private String name;
+    private String profileImage;
+
+    public UserResponseDto(long id, String username, String name, String profileImage) {
+        this.id = id;
+        this.username = username;
+        this.name = name;
+        this.profileImage = profileImage;
+    }
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(user.getId(), user.getUsername(), user.getName(), user.getProfileImage());
+    }
+}

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -20,9 +20,11 @@ oauth:
   github:
     client_id: fbfd3db42dc5b227d1b8
     client_secret: ${GITHUB_CLIENT_SECRET}
+    redirect_url: https://github.com/login/oauth/authorize?client_id=${oauth.github.client_id}&scope=user:email
   google:
     client_id: 886648386281-q6205r09trl1iu29qa09b2sdufbvhgth.apps.googleusercontent.com
     client_secret: ${GOOGLE_CLIENT_SECRET}
+    redirect_url: https://accounts.google.com/o/oauth2/v2/auth?client_id=${oauth.github.client_id}&redirect_uri=${oauth.redirect_url}/oauth/google/callback&response_type=code&scope=profile email'
 
 auth:
   jwt:

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    open-in-view: false
 
 logging:
   level.com.codesquad.issuetracker: debug


### PR DESCRIPTION
안녕하세요 피터! 항상 시간내서 리뷰해주시는 점 감사합니다 🙇🏻‍♂️
4번째 pr 제출합니다.

### 이번 PR에서 진행한 사항

- [x] 액세스 토큰 재발급 api 구현
- [x] 비밀번호 암호화
- [x] 인터셉터에서 유저를 조회하던 로직을 제거

말씀해주셨던 OAuth 다형성 구현은 시간이 없어서 바로 적용하지는 못했습니다..
추후에 적용해보겠습니다!

### 고민 사항

#### 1. 유저정보 조회 로직 중복을 피하는 방법?
유저의 정보를 각 api에서 매번 사용하게 될 경우 서비스의 모든 api에서 조회하는 코드가 중복될 것 같다고 판단했습니다.
그래서 처음에는 인터셉터에서 유저 객체를 조회한 뒤 컨트롤러에게 넘겨주도록 구현했습니다.
하지만 (핸들러 인터셉터가 실행된 이후 영속성 컨텍스트가 생성되어서) 그렇게 넘겨준 객체를 영속성 컨텍스트에서 관리해주지 않는다는것을 알게 되었고, 차선책으로 ArgumentResolver에서 유저 객체를 조회해서 컨트롤러에게 넘겨주도록 하는 방식을 고려했습니다.
(현재는 저희 서비스에서는 특정 api에서만 유저의 정보를 사용할것이라고 생각되어서 userId만 넘겨주도록 변경한 상태입니다.)

**만약 대부분의 api에서 유저 정보가 필요한 경우 ArgumentResolver에서 조회를 하는것은 좋은 패턴일까요? 또한 다른 해결 방법이 있는지 궁금합니다!**
