### PR TITLE
[team-07] [Hwi & 땃쥐] issuetracker 4차 PR

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/IssuetrackerApplication.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/IssuetrackerApplication.java
@@ -2,7 +2,9 @@ package com.codesquad.issuetracker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class IssuetrackerApplication {
 

--- a/BE/src/main/java/com/codesquad/issuetracker/IssuetrackerApplication.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/IssuetrackerApplication.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class IssuetrackerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(IssuetrackerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(IssuetrackerApplication.class, args);
+    }
 
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/BaseTimeEntity.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.codesquad.issuetracker.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Comment.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Comment.java
@@ -6,15 +6,12 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-import java.time.LocalDateTime;
-
 import static javax.persistence.FetchType.LAZY;
-
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,9 +19,6 @@ public class Comment {
     private Long id;
 
     private String content;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime lastModifiedAt;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "author_id")
@@ -34,10 +28,8 @@ public class Comment {
     @JoinColumn(name = "issue_id")
     private Issue issue;
 
-    public Comment(String content, LocalDateTime createdAt, LocalDateTime lastModifiedAt, Member author, Issue issue) {
+    public Comment(String content, Member author, Issue issue) {
         this.content = content;
-        this.createdAt = createdAt;
-        this.lastModifiedAt = lastModifiedAt;
         this.author = author;
         this.issue = issue;
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -3,7 +3,6 @@ package com.codesquad.issuetracker.domain;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,16 +13,12 @@ import static javax.persistence.FetchType.LAZY;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(of = {"id", "title", "content", "isOpened", "createdAt", "lastModifiedAt"})
-public class Issue {
+public class Issue extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "issue_id")
     private Long id;
-
-    private LocalDateTime createdAt;
-
-    private LocalDateTime lastModifiedAt;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "author_id")
@@ -48,9 +43,7 @@ public class Issue {
     private boolean isOpened;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Issue(LocalDateTime createdAt, LocalDateTime lastModifiedAt, Member author, Milestone milestone,String title, String content, boolean isOpened) {
-        this.createdAt = createdAt;
-        this.lastModifiedAt = lastModifiedAt;
+    private Issue(Member author, Milestone milestone,String title, String content, boolean isOpened) {
         this.author = author;
         this.milestone = milestone;
         this.title = title;
@@ -59,17 +52,13 @@ public class Issue {
     }
 
     public static Issue create(String title, String content, Member author, Milestone milestone) {
-        LocalDateTime createdTime = LocalDateTime.now();
-        Issue issue = Issue.builder()
+        return Issue.builder()
                 .author(author)
                 .milestone(milestone)
                 .title(title)
                 .content(content)
-                .createdAt(createdTime)
-                .lastModifiedAt(createdTime)
                 .isOpened(true)
                 .build();
-        return issue;
     }
 
     /**
@@ -88,7 +77,6 @@ public class Issue {
      */
     public void changeIssueState(boolean isOpened) {
         this.isOpened = isOpened;
-        lastModifiedAt = LocalDateTime.now();
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -35,7 +35,7 @@ public class Issue extends BaseTimeEntity {
     private Milestone milestone;
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<IssueLabel> issueLabels = new ArrayList<>();
+    private final Set<IssueLabel> issueLabels = new HashSet<>();
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> comments = new ArrayList<>();

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -145,4 +145,25 @@ public class Issue extends BaseTimeEntity {
                 .map(newLabel -> new IssueLabel(this, newLabel))
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 제목 변경
+     */
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * 본문 변경
+     */
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * 마일스톤 변경
+     */
+    public void changeMilestone(Milestone updateMilestone) {
+        this.milestone = milestone;
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -43,7 +43,7 @@ public class Issue extends BaseTimeEntity {
     private boolean isOpened;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Issue(Member author, Milestone milestone,String title, String content, boolean isOpened) {
+    private Issue(Member author, Milestone milestone, String title, String content, boolean isOpened) {
         this.author = author;
         this.milestone = milestone;
         this.title = title;

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -115,7 +115,7 @@ public class Issue extends BaseTimeEntity {
      */
     public void removeIssueLabelsNotIn(List<IssueLabel> otherIssueLabels) {
         this.issueLabels.removeIf(
-                issueLabel -> !issueLabels.contains(issueLabel)
+                issueLabel -> !otherIssueLabels.contains(issueLabel)
         );
     }
 

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -89,7 +89,7 @@ public class Issue extends BaseTimeEntity {
     }
 
     /**
-     * 기존에 추가되지 않은 회원들을 할당
+     * 기존에 추가되지 않은 회원들로 IssueAssignee 생성
      */
     private List<IssueAssignee> createNewAssignees(List<Member> changeMembers) {
         return changeMembers.stream()
@@ -107,4 +107,42 @@ public class Issue extends BaseTimeEntity {
         changeMembers.removeIf(beforeMembers::contains);
     }
 
+    /**
+     * 지정 Label들로 현재 이슈를 교체(포함되지 않은 라벨들 제거)
+     */
+    public void changeIssueLabels(List<Label> changeLabels) {
+        removeIssueLabelsNotIn(changeLabels);
+        removeDuplicateLabelFrom(changeLabels);
+
+        List<IssueLabel> newLabels = createNewIssueLabels(changeLabels);
+        issueLabels.addAll(newLabels);
+    }
+
+    /**
+     * 리스트에 없는 라벨을 제거
+     */
+    private void removeIssueLabelsNotIn(List<Label> changeLabels) {
+        this.issueLabels.removeIf(
+                issueLabel -> !issueLabel.isLabelBelongTo(changeLabels)
+        );
+    }
+
+    /**
+     * 리스트에 존재하는 라벨이 이미 존재하면 changeLabels에서 제거
+     */
+    private void removeDuplicateLabelFrom(List<Label> changeLabels) {
+        List<Label> beforeLabels = issueLabels.stream()
+                .map(IssueLabel::getLabel)
+                .collect(Collectors.toList());
+        changeLabels.removeIf(beforeLabels::contains);
+    }
+
+    /**
+     * 기존에 추가되지 않은 라벨들로 이슈라벨을 생성
+     */
+    private List<IssueLabel> createNewIssueLabels(List<Label> changeLabels) {
+        return changeLabels.stream()
+                .map(newLabel -> new IssueLabel(this, newLabel))
+                .collect(Collectors.toList());
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Issue.java
@@ -25,17 +25,17 @@ public class Issue extends BaseTimeEntity {
     private Member author;
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<IssueAssignee> assignees = new ArrayList<>();
+    private final List<IssueAssignee> assignees = new ArrayList<>();
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "milestone_id")
     private Milestone milestone;
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<IssueLabel> issueLabels = new ArrayList<>();
+    private final List<IssueLabel> issueLabels = new ArrayList<>();
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+    private final List<Comment> comments = new ArrayList<>();
 
     private String title;
     private String content;

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/IssueAssignee.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/IssueAssignee.java
@@ -1,18 +1,21 @@
 package com.codesquad.issuetracker.domain;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static javax.persistence.FetchType.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"member", "issue"})
 public class IssueAssignee {
 
     @Id
@@ -28,13 +31,18 @@ public class IssueAssignee {
     @JoinColumn(name = "issue_id")
     private Issue issue;
 
-    IssueAssignee(Member member, Issue issue) {
+    public IssueAssignee(Member member, Issue issue) {
         this.member = member;
         this.issue = issue;
     }
 
-    public boolean isMemberBelongTo(List<Member> members) {
-        return members.contains(member);
+    public static List<IssueAssignee> createIssueAssignees(Issue issue, List<Member> members) {
+        return members.stream()
+                .map(member -> new IssueAssignee(member, issue))
+                .collect(Collectors.toList());
     }
 
+    public boolean hasDifferentIssue(Issue otherIssue) {
+        return !(issue.equals(otherIssue));
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/IssueAssignee.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/IssueAssignee.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.List;
+
 import static javax.persistence.FetchType.*;
 
 @Entity
@@ -26,18 +28,13 @@ public class IssueAssignee {
     @JoinColumn(name = "issue_id")
     private Issue issue;
 
-    private IssueAssignee(Member member, Issue issue) {
+    IssueAssignee(Member member, Issue issue) {
         this.member = member;
         this.issue = issue;
     }
 
-    /**
-     * 이슈에 회원을 할당하기 위해 사용하는 편의 메서드
-     * Issue에 종속적임. 생성 시 Issue에서만 생성하도록 하고 package-private로 함
-     */
-    static void assignMemberToIssue(Member member, Issue issue) {
-        IssueAssignee issueAssignee = new IssueAssignee(member, issue);
-        issue.getAssignees().add(issueAssignee);
+    public boolean isMemberBelongTo(List<Member> members) {
+        return members.contains(member);
     }
 
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/IssueLabel.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/IssueLabel.java
@@ -1,15 +1,18 @@
 package com.codesquad.issuetracker.domain;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"issue", "label"})
 public class IssueLabel {
 
     @Id
@@ -25,14 +28,18 @@ public class IssueLabel {
     @JoinColumn(name = "label_id")
     private Label label;
 
-    IssueLabel(Issue issue, Label label) {
-        this.issue = issue;
+    public IssueLabel(Label label, Issue issue) {
         this.label = label;
+        this.issue = issue;
     }
 
-
-    public boolean isLabelBelongTo(List<Label> labels) {
-        return labels.contains(label);
+    public static List<IssueLabel> createIssueLabels(Issue issue, List<Label> labels) {
+        return labels.stream()
+                .map(label -> new IssueLabel(label, issue))
+                .collect(Collectors.toList());
     }
 
+    public boolean hasDifferentIssue(Issue otherIssue) {
+        return !(issue.equals(otherIssue));
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/IssueLabel.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/IssueLabel.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -24,18 +25,14 @@ public class IssueLabel {
     @JoinColumn(name = "label_id")
     private Label label;
 
-    private IssueLabel(Issue issue, Label label) {
+    IssueLabel(Issue issue, Label label) {
         this.issue = issue;
         this.label = label;
     }
 
-    /**
-     * 이슈에 라벨을 할당하기 위해 사용하는 편의 메서드
-     * Issue에 종속적임. 생성 시 Issue에서만 생성하도록 하고 package-private로 함
-     */
-    static void putLabelToIssue(Label label, Issue issue) {
-        IssueLabel issueLabel = new IssueLabel(issue, label);
-        issue.getIssueLabels().add(issueLabel);
+
+    public boolean isLabelBelongTo(List<Label> labels) {
+        return labels.contains(label);
     }
 
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Label.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Label.java
@@ -3,12 +3,14 @@ package com.codesquad.issuetracker.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Label {
 
     @Id

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/LabelColor.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/LabelColor.java
@@ -2,10 +2,7 @@ package com.codesquad.issuetracker.domain;
 
 import com.codesquad.issuetracker.excption.InvalidColorCodeException;
 import com.codesquad.issuetracker.excption.InvalidColorValueRangeException;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Embeddable;
 
@@ -13,6 +10,7 @@ import javax.persistence.Embeddable;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
+@ToString
 public class LabelColor {
 
     private static final int COLOR_RADIX = 16;

--- a/BE/src/main/java/com/codesquad/issuetracker/domain/Member.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/domain/Member.java
@@ -11,7 +11,8 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
 

--- a/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidColorValueRangeException.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidColorValueRangeException.java
@@ -6,4 +6,3 @@ public class InvalidColorValueRangeException extends BusinessException {
         super(message);
     }
 }
-

--- a/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidIssueAssigneeAddException.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidIssueAssigneeAddException.java
@@ -1,0 +1,11 @@
+package com.codesquad.issuetracker.excption;
+
+/**
+ * 이슈에 IssueAssignee를 할당할 때 다른 Issue에 할당된 IssueAssignee를 추가할 때 발생하는 예외
+ */
+public class InvalidIssueAssigneeAddException extends BusinessException {
+
+    public InvalidIssueAssigneeAddException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidIssueLabelAddException.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/excption/InvalidIssueLabelAddException.java
@@ -1,0 +1,11 @@
+package com.codesquad.issuetracker.excption;
+
+/**
+ * 이슈에 IssueLabel를 할당할 때 다른 Issue에 할당된 IssueLabel를 추가할 때 발생하는 예외
+ */
+public class InvalidIssueLabelAddException extends BusinessException {
+
+    public InvalidIssueLabelAddException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/excption/IssueNotFoundException.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/excption/IssueNotFoundException.java
@@ -1,6 +1,6 @@
 package com.codesquad.issuetracker.excption;
 
-public class IssueNotFoundException extends  BusinessException{
+public class IssueNotFoundException extends BusinessException {
 
     public IssueNotFoundException(String message) {
         super(message);

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/comment/CommentCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/comment/CommentCustomRepository.java
@@ -1,5 +1,11 @@
 package com.codesquad.issuetracker.repository.comment;
 
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
+
+import java.util.List;
+
 public interface CommentCustomRepository {
+
+    List<CommentListElement> findCommentDtosByIssueId(Long issueId);
 
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/comment/CommentRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/comment/CommentRepositoryImpl.java
@@ -1,8 +1,14 @@
 package com.codesquad.issuetracker.repository.comment;
 
+import com.codesquad.issuetracker.domain.QMember;
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
+import com.codesquad.issuetracker.web.dto.comment.QCommentListElement;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.codesquad.issuetracker.domain.QComment.comment;
 
 public class CommentRepositoryImpl implements CommentCustomRepository {
 
@@ -10,5 +16,19 @@ public class CommentRepositoryImpl implements CommentCustomRepository {
 
     public CommentRepositoryImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<CommentListElement> findCommentDtosByIssueId(Long issueId) {
+        QMember author = new QMember("author");
+        return queryFactory
+                .select(
+                        new QCommentListElement(
+                                comment.id, author.id, author.name,
+                                comment.content, comment.createdAt, comment.lastModifiedAt))
+                .from(comment)
+                .join(comment.author, author)
+                .where(comment.issue.id.eq(issueId))
+                .fetch();
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
@@ -1,5 +1,10 @@
 package com.codesquad.issuetracker.repository.issue;
 
+import com.codesquad.issuetracker.domain.Issue;
+
+import java.util.Optional;
+
 public interface IssueCustomRepository {
 
+    Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
@@ -2,9 +2,11 @@ package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IssueCustomRepository {
 
     Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
+    void updateBulkStates(List<Long> issueIds, boolean isOpened);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
@@ -1,5 +1,5 @@
 package com.codesquad.issuetracker.repository.issue;
 
 public interface IssueCustomRepository {
-    
+
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
@@ -1,7 +1,9 @@
 package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
+import com.codesquad.issuetracker.web.dto.issue.IssueAssigneeDto;
 import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
+import com.codesquad.issuetracker.web.dto.issue.IssueLabelDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,6 @@ public interface IssueCustomRepository {
     Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
     void updateBulkStates(List<Long> issueIds, boolean isOpened);
     Optional<IssueDetailResponse> findIssueDetail(Long issueId);
+    List<IssueLabelDto> findIssueLabelDtosByIssueId(Long issueId);
+    List<IssueAssigneeDto> findIssueAssigneeDtosByIssueId(Long issueId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueCustomRepository.java
@@ -1,6 +1,7 @@
 package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
+import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,5 @@ public interface IssueCustomRepository {
 
     Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
     void updateBulkStates(List<Long> issueIds, boolean isOpened);
+    Optional<IssueDetailResponse> findIssueDetail(Long issueId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface IssueRepository extends JpaRepository<Issue, Long>, IssueCustomRepository {
 
-    Optional<Issue> findDetailIssueById(Long issueId);
+    Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepository.java
@@ -3,9 +3,6 @@ package com.codesquad.issuetracker.repository.issue;
 import com.codesquad.issuetracker.domain.Issue;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface IssueRepository extends JpaRepository<Issue, Long>, IssueCustomRepository {
 
-    Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.QMember;
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
+import com.codesquad.issuetracker.web.dto.comment.QCommentListElement;
+import com.codesquad.issuetracker.web.dto.issue.IssueAssigneeDto;
 import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
+import com.codesquad.issuetracker.web.dto.issue.QIssueAssigneeDto;
 import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse;
-import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse_CommentListElement;
-import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse_IssueAssigneeDto;
 import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import com.codesquad.issuetracker.web.dto.label.QLabelDto;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -62,9 +64,9 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
             return Optional.empty();
         }
 
-        List<IssueDetailResponse.IssueAssigneeDto> assigneeDtos = findIssueAssigneeDtos(issueId);
+        List<IssueAssigneeDto> assigneeDtos = findIssueAssigneeDtos(issueId);
         List<LabelDto> labelDtos = findLabelDtos(issueId);
-        List<IssueDetailResponse.CommentListElement> commentDtos = findCommentDtos(issueId);
+        List<CommentListElement> commentDtos = findCommentDtos(issueId);
 
         issueDetailResponse.getAssignees().addAll(assigneeDtos);
         issueDetailResponse.getLabels().addAll(labelDtos);
@@ -73,12 +75,11 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
         return Optional.of(issueDetailResponse);
     }
 
-    private List<IssueDetailResponse.CommentListElement> findCommentDtos(Long issueId) {
+    private List<CommentListElement> findCommentDtos(Long issueId) {
         QMember author = new QMember("author");
-
         return queryFactory
                 .select(
-                        new QIssueDetailResponse_CommentListElement(
+                        new QCommentListElement(
                                 comment.id, author.id, author.name,
                                 comment.content, comment.createdAt, comment.lastModifiedAt))
                 .from(comment)
@@ -97,9 +98,9 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
 
 
 
-    private List<IssueDetailResponse.IssueAssigneeDto> findIssueAssigneeDtos(Long issueId) {
+    private List<IssueAssigneeDto> findIssueAssigneeDtos(Long issueId) {
         return queryFactory
-                .select(new QIssueDetailResponse_IssueAssigneeDto(member.id, member.name))
+                .select(new QIssueAssigneeDto(member.id, member.name))
                 .from(issueAssignee)
                 .join(issueAssignee.member, member)
                 .where(issueAssignee.issue.id.eq(issueId))

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
@@ -2,21 +2,13 @@ package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.QMember;
-import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
-import com.codesquad.issuetracker.web.dto.comment.QCommentListElement;
-import com.codesquad.issuetracker.web.dto.issue.IssueAssigneeDto;
-import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
-import com.codesquad.issuetracker.web.dto.issue.QIssueAssigneeDto;
-import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse;
-import com.codesquad.issuetracker.web.dto.label.LabelDto;
-import com.codesquad.issuetracker.web.dto.label.QLabelDto;
+import com.codesquad.issuetracker.web.dto.issue.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.codesquad.issuetracker.domain.QComment.comment;
 import static com.codesquad.issuetracker.domain.QIssue.issue;
 import static com.codesquad.issuetracker.domain.QIssueAssignee.issueAssignee;
 import static com.codesquad.issuetracker.domain.QIssueLabel.issueLabel;
@@ -57,60 +49,9 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
 
     @Override
     public Optional<IssueDetailResponse> findIssueDetail(Long issueId) {
-
-        IssueDetailResponse issueDetailResponse = getIssueDetailResponse(issueId);
-
-        if (issueDetailResponse == null) {
-            return Optional.empty();
-        }
-
-        List<IssueAssigneeDto> assigneeDtos = findIssueAssigneeDtos(issueId);
-        List<LabelDto> labelDtos = findLabelDtos(issueId);
-        List<CommentListElement> commentDtos = findCommentDtos(issueId);
-
-        issueDetailResponse.getAssignees().addAll(assigneeDtos);
-        issueDetailResponse.getLabels().addAll(labelDtos);
-        issueDetailResponse.getComments().addAll(commentDtos);
-
-        return Optional.of(issueDetailResponse);
-    }
-
-    private List<CommentListElement> findCommentDtos(Long issueId) {
-        QMember author = new QMember("author");
-        return queryFactory
-                .select(
-                        new QCommentListElement(
-                                comment.id, author.id, author.name,
-                                comment.content, comment.createdAt, comment.lastModifiedAt))
-                .from(comment)
-                .join(comment.author, author)
-                .where(comment.issue.id.eq(issueId))
-                .fetch();
-    }
-
-    private List<LabelDto> findLabelDtos(Long issueId) {
-        return queryFactory.select(new QLabelDto(label.id, label.name, label.labelColor))
-                .from(issueLabel)
-                .join(issueLabel.label, label)
-                .where(issueLabel.issue.id.eq(issueId))
-                .fetch();
-    }
-
-
-
-    private List<IssueAssigneeDto> findIssueAssigneeDtos(Long issueId) {
-        return queryFactory
-                .select(new QIssueAssigneeDto(member.id, member.name))
-                .from(issueAssignee)
-                .join(issueAssignee.member, member)
-                .where(issueAssignee.issue.id.eq(issueId))
-                .fetch();
-    }
-
-    private IssueDetailResponse getIssueDetailResponse(Long issueId) {
         QMember author = new QMember("author");
 
-        return queryFactory
+        IssueDetailResponse issueDetailResponse = queryFactory
                 .select(
                         new QIssueDetailResponse(
                                 issue.id, author.id, author.name, issue.title,
@@ -122,5 +63,26 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
                 .leftJoin(issue.milestone, milestone)
                 .where(issue.id.eq(issueId))
                 .fetchOne();
+
+        return Optional.ofNullable(issueDetailResponse);
+    }
+
+    @Override
+    public List<IssueLabelDto> findIssueLabelDtosByIssueId(Long issueId) {
+        return queryFactory.select(new QIssueLabelDto(label.id, label.name, label.labelColor))
+                .from(issueLabel)
+                .join(issueLabel.label, label)
+                .where(issueLabel.issue.id.eq(issueId))
+                .fetch();
+    }
+
+    @Override
+    public List<IssueAssigneeDto> findIssueAssigneeDtosByIssueId(Long issueId) {
+        return queryFactory
+                .select(new QIssueAssigneeDto(member.id, member.name))
+                .from(issueAssignee)
+                .join(issueAssignee.member, member)
+                .where(issueAssignee.issue.id.eq(issueId))
+                .fetch();
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
@@ -20,7 +20,7 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    public Optional<Issue> findDetailIssueById(Long issueId) {
+    public Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId) {
         QMember author = new QMember("author");
 
         Issue findIssue = queryFactory.select(issue)

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
@@ -2,14 +2,24 @@ package com.codesquad.issuetracker.repository.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.QMember;
+import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
+import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse;
+import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse_CommentListElement;
+import com.codesquad.issuetracker.web.dto.issue.QIssueDetailResponse_IssueAssigneeDto;
+import com.codesquad.issuetracker.web.dto.label.LabelDto;
+import com.codesquad.issuetracker.web.dto.label.QLabelDto;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
-
 import java.util.List;
 import java.util.Optional;
 
-import static com.codesquad.issuetracker.domain.QIssue.*;
+import static com.codesquad.issuetracker.domain.QComment.comment;
+import static com.codesquad.issuetracker.domain.QIssue.issue;
+import static com.codesquad.issuetracker.domain.QIssueAssignee.issueAssignee;
+import static com.codesquad.issuetracker.domain.QIssueLabel.issueLabel;
+import static com.codesquad.issuetracker.domain.QLabel.label;
+import static com.codesquad.issuetracker.domain.QMember.member;
 import static com.codesquad.issuetracker.domain.QMilestone.milestone;
 
 
@@ -41,5 +51,75 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
                 .set(issue.isOpened, isOpened)
                 .where(issue.id.in(issueIds))
                 .execute();
+    }
+
+    @Override
+    public Optional<IssueDetailResponse> findIssueDetail(Long issueId) {
+
+        IssueDetailResponse issueDetailResponse = getIssueDetailResponse(issueId);
+
+        if (issueDetailResponse == null) {
+            return Optional.empty();
+        }
+
+        List<IssueDetailResponse.IssueAssigneeDto> assigneeDtos = findIssueAssigneeDtos(issueId);
+        List<LabelDto> labelDtos = findLabelDtos(issueId);
+        List<IssueDetailResponse.CommentListElement> commentDtos = findCommentDtos(issueId);
+
+        issueDetailResponse.getAssignees().addAll(assigneeDtos);
+        issueDetailResponse.getLabels().addAll(labelDtos);
+        issueDetailResponse.getComments().addAll(commentDtos);
+
+        return Optional.of(issueDetailResponse);
+    }
+
+    private List<IssueDetailResponse.CommentListElement> findCommentDtos(Long issueId) {
+        QMember author = new QMember("author");
+
+        return queryFactory
+                .select(
+                        new QIssueDetailResponse_CommentListElement(
+                                comment.id, author.id, author.name,
+                                comment.content, comment.createdAt, comment.lastModifiedAt))
+                .from(comment)
+                .join(comment.author, author)
+                .where(comment.issue.id.eq(issueId))
+                .fetch();
+    }
+
+    private List<LabelDto> findLabelDtos(Long issueId) {
+        return queryFactory.select(new QLabelDto(label.id, label.name, label.labelColor))
+                .from(issueLabel)
+                .join(issueLabel.label, label)
+                .where(issueLabel.issue.id.eq(issueId))
+                .fetch();
+    }
+
+
+
+    private List<IssueDetailResponse.IssueAssigneeDto> findIssueAssigneeDtos(Long issueId) {
+        return queryFactory
+                .select(new QIssueDetailResponse_IssueAssigneeDto(member.id, member.name))
+                .from(issueAssignee)
+                .join(issueAssignee.member, member)
+                .where(issueAssignee.issue.id.eq(issueId))
+                .fetch();
+    }
+
+    private IssueDetailResponse getIssueDetailResponse(Long issueId) {
+        QMember author = new QMember("author");
+
+        return queryFactory
+                .select(
+                        new QIssueDetailResponse(
+                                issue.id, author.id, author.name, issue.title,
+                                issue.content, milestone.id, milestone.title, issue.isOpened,
+                                issue.createdAt, issue.lastModifiedAt
+                        ))
+                .from(issue)
+                .join(issue.author, author)
+                .leftJoin(issue.milestone, milestone)
+                .where(issue.id.eq(issueId))
+                .fetchOne();
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/repository/issue/IssueRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.codesquad.issuetracker.domain.QIssue.*;
@@ -20,6 +21,7 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
+    @Override
     public Optional<Issue> findByIdWithAuthorAndMilestone(Long issueId) {
         QMember author = new QMember("author");
 
@@ -31,5 +33,13 @@ public class IssueRepositoryImpl implements IssueCustomRepository {
                 .fetchOne();
 
         return Optional.ofNullable(findIssue);
+    }
+
+    @Override
+    public void updateBulkStates(List<Long> issueIds, boolean isOpened) {
+        queryFactory.update(issue)
+                .set(issue.isOpened, isOpened)
+                .where(issue.id.in(issueIds))
+                .execute();
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/comment/CommentQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/comment/CommentQueryService.java
@@ -1,0 +1,23 @@
+package com.codesquad.issuetracker.service.comment;
+
+import com.codesquad.issuetracker.repository.comment.CommentRepository;
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+    private final CommentRepository commentRepository;
+
+    public List<CommentListElement> findCommentDtosByIssueId(Long issueId) {
+        return commentRepository.findCommentDtosByIssueId(issueId);
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -11,7 +11,7 @@ import com.codesquad.issuetracker.repository.issue.IssueRepository;
 import com.codesquad.issuetracker.repository.label.LabelRepository;
 import com.codesquad.issuetracker.repository.member.MemberRepository;
 import com.codesquad.issuetracker.repository.milestone.MilestoneRepository;
-import com.codesquad.issuetracker.web.dto.IssueUpdateRequest;
+import com.codesquad.issuetracker.web.dto.issue.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -26,6 +26,8 @@ import java.util.List;
 public class IssueCommandService {
 
     private final IssueRepository issueRepository;
+
+    private final IssueQueryService issueQueryService;
     private final MemberRepository memberRepository;
     private final MilestoneRepository milestoneRepository;
     private final LabelRepository labelRepository;
@@ -63,13 +65,8 @@ public class IssueCommandService {
     }
 
     public void changeState(Long issueId, boolean isOpened) {
-        Issue issue = findIssue(issueId);
+        Issue issue = issueQueryService.findIssueById(issueId);
         issue.changeIssueState(isOpened);
-    }
-
-    private Issue findIssue(Long issueId) {
-        return issueRepository.findById(issueId)
-                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈가 존재하지 않습니다."));
     }
 
     public void changeStates(List<Long> issueIds, boolean isOpened) {

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -60,8 +60,10 @@ public class IssueCommandService {
         issueRepository.updateBulkStates(issueIds, isOpened);
     }
 
-    public void deleteIssue(Long issueId) {
-        issueRepository.deleteById(issueId);
+    public boolean deleteIssue(Long issueId) {
+        Issue issue = issueQueryService.findIssueById(issueId);
+        issueRepository.delete(issue);
+        return true;
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -49,7 +49,7 @@ public class IssueCommandService {
         return (milestoneId == null)
                 ? null
                 : milestoneRepository.findById(milestoneId)
-                        .orElseThrow(() -> new MilestoneNotFoundException("일치하는 식별자의 마일스톤이 존재하지 않습니다."));
+                .orElseThrow(() -> new MilestoneNotFoundException("일치하는 식별자의 마일스톤이 존재하지 않습니다."));
     }
 
     private Member findMember(Long memberId) {

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -1,6 +1,9 @@
 package com.codesquad.issuetracker.service.issue;
 
-import com.codesquad.issuetracker.domain.*;
+import com.codesquad.issuetracker.domain.Issue;
+import com.codesquad.issuetracker.domain.Label;
+import com.codesquad.issuetracker.domain.Member;
+import com.codesquad.issuetracker.domain.Milestone;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.excption.MemberNotFoundException;
 import com.codesquad.issuetracker.excption.MilestoneNotFoundException;
@@ -8,6 +11,7 @@ import com.codesquad.issuetracker.repository.issue.IssueRepository;
 import com.codesquad.issuetracker.repository.label.LabelRepository;
 import com.codesquad.issuetracker.repository.member.MemberRepository;
 import com.codesquad.issuetracker.repository.milestone.MilestoneRepository;
+import com.codesquad.issuetracker.web.dto.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -77,5 +81,22 @@ public class IssueCommandService {
     public void deleteIssue(Long issueId) {
         issueRepository.deleteById(issueId);
 
+    }
+
+    /**
+     * 이슈 수정
+     */
+    public void updateIssue(Long issueId, IssueUpdateRequest updateRequest) {
+        Issue issue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
+                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
+        Milestone updateMilestone = findMilestone(updateRequest.getMilestoneId());
+        List<Label> labels = labelRepository.findAllById(updateRequest.getLabelIds());
+        List<Member> assigneeMembers = memberRepository.findAllById(updateRequest.getAssigneeIds());
+
+        issue.changeTitle(updateRequest.getTitle());
+        issue.changeContent(updateRequest.getContent());
+        issue.changeMilestone(updateMilestone);
+        issue.changeIssueAssignees(assigneeMembers);
+        issue.changeIssueLabels(labels);
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -1,9 +1,6 @@
 package com.codesquad.issuetracker.service.issue;
 
-import com.codesquad.issuetracker.domain.Issue;
-import com.codesquad.issuetracker.domain.Label;
-import com.codesquad.issuetracker.domain.Member;
-import com.codesquad.issuetracker.domain.Milestone;
+import com.codesquad.issuetracker.domain.*;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.excption.MemberNotFoundException;
 import com.codesquad.issuetracker.excption.MilestoneNotFoundException;
@@ -38,7 +35,9 @@ public class IssueCommandService {
         Milestone milestone = findMilestone(milestondId);
         List<Label> labels = labelRepository.findAllById(labelIds);
 
-        Issue issue = Issue.create(author, assigneeMembers, milestone, labels, title, content);
+        Issue issue = Issue.create(title, content, author, milestone);
+        issue.changeIssueAssignees(assigneeMembers);
+
         issueRepository.save(issue);
 
         log.info("created Issue = {}", issue);

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -6,7 +6,7 @@ import com.codesquad.issuetracker.domain.Member;
 import com.codesquad.issuetracker.domain.Milestone;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
-import com.codesquad.issuetracker.repository.label.LabelRepository;
+import com.codesquad.issuetracker.service.label.LabelQueryService;
 import com.codesquad.issuetracker.service.member.MemberQueryService;
 import com.codesquad.issuetracker.service.milestone.MilestoneQueryService;
 import com.codesquad.issuetracker.web.dto.issue.IssueUpdateRequest;
@@ -28,7 +28,7 @@ public class IssueCommandService {
     private final IssueQueryService issueQueryService;
     private final MemberQueryService memberQueryService;
     private final MilestoneQueryService milestoneQueryService;
-    private final LabelRepository labelRepository;
+    private final LabelQueryService labelQueryService;
 
     /**
      * 이슈 생성
@@ -37,7 +37,7 @@ public class IssueCommandService {
         Member author = memberQueryService.findMemberById(authorId);
         List<Member> assigneeMembers = memberQueryService.findAllById(assigneeIds);
         Milestone milestone = milestoneQueryService.findMilestoneById(milestondId);
-        List<Label> labels = labelRepository.findAllById(labelIds);
+        List<Label> labels = labelQueryService.findAllById(labelIds);
 
         Issue issue = Issue.create(title, content, author, milestone);
         issue.changeIssueAssignees(assigneeMembers);
@@ -70,7 +70,7 @@ public class IssueCommandService {
         Issue issue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
                 .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
         Milestone updateMilestone = milestoneQueryService.findMilestoneById(updateRequest.getMilestoneId());
-        List<Label> labels = labelRepository.findAllById(updateRequest.getLabelIds());
+        List<Label> labels = labelQueryService.findAllById(updateRequest.getLabelIds());
         List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());
 
         issue.changeTitle(updateRequest.getTitle());

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -37,6 +37,7 @@ public class IssueCommandService {
 
         Issue issue = Issue.create(title, content, author, milestone);
         issue.changeIssueAssignees(assigneeMembers);
+        issue.changeIssueLabels(labels);
 
         issueRepository.save(issue);
 

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -5,11 +5,10 @@ import com.codesquad.issuetracker.domain.Label;
 import com.codesquad.issuetracker.domain.Member;
 import com.codesquad.issuetracker.domain.Milestone;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
-import com.codesquad.issuetracker.excption.MilestoneNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
 import com.codesquad.issuetracker.repository.label.LabelRepository;
-import com.codesquad.issuetracker.repository.milestone.MilestoneRepository;
 import com.codesquad.issuetracker.service.member.MemberQueryService;
+import com.codesquad.issuetracker.service.milestone.MilestoneQueryService;
 import com.codesquad.issuetracker.web.dto.issue.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +27,7 @@ public class IssueCommandService {
 
     private final IssueQueryService issueQueryService;
     private final MemberQueryService memberQueryService;
-    private final MilestoneRepository milestoneRepository;
+    private final MilestoneQueryService milestoneQueryService;
     private final LabelRepository labelRepository;
 
     /**
@@ -37,7 +36,7 @@ public class IssueCommandService {
     public Long createIssue(Long authorId, List<Long> assigneeIds, Long milestondId, List<Long> labelIds, String title, String content) {
         Member author = memberQueryService.findMemberById(authorId);
         List<Member> assigneeMembers = memberQueryService.findAllById(assigneeIds);
-        Milestone milestone = findMilestone(milestondId);
+        Milestone milestone = milestoneQueryService.findMilestoneById(milestondId);
         List<Label> labels = labelRepository.findAllById(labelIds);
 
         Issue issue = Issue.create(title, content, author, milestone);
@@ -49,13 +48,6 @@ public class IssueCommandService {
         log.info("created Issue = {}", issue);
 
         return issue.getId();
-    }
-
-    private Milestone findMilestone(Long milestoneId) {
-        return (milestoneId == null)
-                ? null
-                : milestoneRepository.findById(milestoneId)
-                .orElseThrow(() -> new MilestoneNotFoundException("일치하는 식별자의 마일스톤이 존재하지 않습니다."));
     }
 
     public void changeState(Long issueId, boolean isOpened) {
@@ -77,7 +69,7 @@ public class IssueCommandService {
     public void updateIssue(Long issueId, IssueUpdateRequest updateRequest) {
         Issue issue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
                 .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
-        Milestone updateMilestone = findMilestone(updateRequest.getMilestoneId());
+        Milestone updateMilestone = milestoneQueryService.findMilestoneById(updateRequest.getMilestoneId());
         List<Label> labels = labelRepository.findAllById(updateRequest.getLabelIds());
         List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());
 

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -70,8 +70,7 @@ public class IssueCommandService {
      * 이슈 수정
      */
     public void updateIssue(Long issueId, IssueUpdateRequest updateRequest) {
-        Issue issue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
-                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
+        Issue issue = issueQueryService.findByIdWithAuthorAndMilestone(issueId);
         Milestone updateMilestone = milestoneQueryService.findMilestoneById(updateRequest.getMilestoneId());
         List<Label> labels = labelQueryService.findAllById(updateRequest.getLabelIds());
         List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -1,9 +1,6 @@
 package com.codesquad.issuetracker.service.issue;
 
-import com.codesquad.issuetracker.domain.Issue;
-import com.codesquad.issuetracker.domain.Label;
-import com.codesquad.issuetracker.domain.Member;
-import com.codesquad.issuetracker.domain.Milestone;
+import com.codesquad.issuetracker.domain.*;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
 import com.codesquad.issuetracker.service.label.LabelQueryService;
@@ -40,7 +37,10 @@ public class IssueCommandService {
         List<Label> labels = labelQueryService.findAllById(labelIds);
 
         Issue issue = Issue.create(title, content, author, milestone);
-        issue.changeIssueAssignees(assigneeMembers);
+
+        List<IssueAssignee> assignees = IssueAssignee.createIssueAssignees(issue, assigneeMembers);
+        issue.addIssueAssignees(assignees);
+
         issue.changeIssueLabels(labels);
 
         issueRepository.save(issue);
@@ -73,10 +73,15 @@ public class IssueCommandService {
         List<Label> labels = labelQueryService.findAllById(updateRequest.getLabelIds());
         List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());
 
+
         issue.changeTitle(updateRequest.getTitle());
         issue.changeContent(updateRequest.getContent());
         issue.changeMilestone(updateMilestone);
-        issue.changeIssueAssignees(assigneeMembers);
+
+        List<IssueAssignee> issueAssignees = IssueAssignee.createIssueAssignees(issue, assigneeMembers);
+        issue.removeAssigneesNotIn(issueAssignees);
+        issue.addIssueAssignees(issueAssignees);
+
         issue.changeIssueLabels(labels);
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -5,12 +5,11 @@ import com.codesquad.issuetracker.domain.Label;
 import com.codesquad.issuetracker.domain.Member;
 import com.codesquad.issuetracker.domain.Milestone;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
-import com.codesquad.issuetracker.excption.MemberNotFoundException;
 import com.codesquad.issuetracker.excption.MilestoneNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
 import com.codesquad.issuetracker.repository.label.LabelRepository;
-import com.codesquad.issuetracker.repository.member.MemberRepository;
 import com.codesquad.issuetracker.repository.milestone.MilestoneRepository;
+import com.codesquad.issuetracker.service.member.MemberQueryService;
 import com.codesquad.issuetracker.web.dto.issue.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +27,7 @@ public class IssueCommandService {
     private final IssueRepository issueRepository;
 
     private final IssueQueryService issueQueryService;
-    private final MemberRepository memberRepository;
+    private final MemberQueryService memberQueryService;
     private final MilestoneRepository milestoneRepository;
     private final LabelRepository labelRepository;
 
@@ -36,8 +35,8 @@ public class IssueCommandService {
      * 이슈 생성
      */
     public Long createIssue(Long authorId, List<Long> assigneeIds, Long milestondId, List<Long> labelIds, String title, String content) {
-        Member author = findMember(authorId);
-        List<Member> assigneeMembers = memberRepository.findAllById(assigneeIds);
+        Member author = memberQueryService.findMemberById(authorId);
+        List<Member> assigneeMembers = memberQueryService.findAllById(assigneeIds);
         Milestone milestone = findMilestone(milestondId);
         List<Label> labels = labelRepository.findAllById(labelIds);
 
@@ -57,11 +56,6 @@ public class IssueCommandService {
                 ? null
                 : milestoneRepository.findById(milestoneId)
                 .orElseThrow(() -> new MilestoneNotFoundException("일치하는 식별자의 마일스톤이 존재하지 않습니다."));
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("일치하는 식별자의 회원이 존재하지 않습니다."));
     }
 
     public void changeState(Long issueId, boolean isOpened) {
@@ -85,7 +79,7 @@ public class IssueCommandService {
                 .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
         Milestone updateMilestone = findMilestone(updateRequest.getMilestoneId());
         List<Label> labels = labelRepository.findAllById(updateRequest.getLabelIds());
-        List<Member> assigneeMembers = memberRepository.findAllById(updateRequest.getAssigneeIds());
+        List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());
 
         issue.changeTitle(updateRequest.getTitle());
         issue.changeContent(updateRequest.getContent());

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -39,9 +39,10 @@ public class IssueCommandService {
         Issue issue = Issue.create(title, content, author, milestone);
 
         List<IssueAssignee> assignees = IssueAssignee.createIssueAssignees(issue, assigneeMembers);
-        issue.addIssueAssignees(assignees);
+        List<IssueLabel> issueLabels = IssueLabel.createIssueLabels(issue, labels);
 
-        issue.changeIssueLabels(labels);
+        issue.addIssueAssignees(assignees);
+        issue.addIssueLabels(issueLabels);
 
         issueRepository.save(issue);
 
@@ -73,7 +74,6 @@ public class IssueCommandService {
         List<Label> labels = labelQueryService.findAllById(updateRequest.getLabelIds());
         List<Member> assigneeMembers = memberQueryService.findAllById(updateRequest.getAssigneeIds());
 
-
         issue.changeTitle(updateRequest.getTitle());
         issue.changeContent(updateRequest.getContent());
         issue.changeMilestone(updateMilestone);
@@ -82,6 +82,8 @@ public class IssueCommandService {
         issue.removeAssigneesNotIn(issueAssignees);
         issue.addIssueAssignees(issueAssignees);
 
-        issue.changeIssueLabels(labels);
+        List<IssueLabel> issueLabels = IssueLabel.createIssueLabels(issue, labels);
+        issue.removeIssueLabelsNotIn(issueLabels);
+        issue.addIssueLabels(issueLabels);
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueCommandService.java
@@ -73,14 +73,11 @@ public class IssueCommandService {
     }
 
     public void changeStates(List<Long> issueIds, boolean isOpened) {
-        List<Issue> issues = issueRepository.findAllById(issueIds);
-
-        issues.forEach(issue -> issue.changeIssueState(isOpened));
+        issueRepository.updateBulkStates(issueIds, isOpened);
     }
 
     public void deleteIssue(Long issueId) {
         issueRepository.deleteById(issueId);
-
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -1,11 +1,9 @@
 package com.codesquad.issuetracker.service.issue;
 
-import com.codesquad.issuetracker.domain.Comment;
 import com.codesquad.issuetracker.domain.Issue;
-import com.codesquad.issuetracker.domain.IssueAssignee;
-import com.codesquad.issuetracker.domain.IssueLabel;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
+import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,26 +32,8 @@ public class IssueQueryService {
         return issueRepository.existsById(issueId);
     }
 
-    public Issue findDetailIssue(Long issueId) {
-        Issue detailIssue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
-                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
-
-
-        List<IssueLabel> issueLabels = detailIssue.getIssueLabels();
-        for (IssueLabel issueLabel : issueLabels) {
-            issueLabel.getLabel();
-        }
-
-        List<IssueAssignee> assignees = detailIssue.getAssignees();
-        for (IssueAssignee assignee : assignees) {
-            assignee.getMember();
-        }
-
-        List<Comment> comments = detailIssue.getComments();
-        for (Comment comment : comments) {
-            comment.getAuthor();
-        }
-
-        return detailIssue;
+    public IssueDetailResponse findDetailIssue(Long issueId) {
+        return issueRepository.findIssueDetail(issueId)
+                .orElseThrow(()-> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -34,10 +34,6 @@ public class IssueQueryService {
         return issueRepository.findAllById(issueIds);
     }
 
-    public boolean checkIssueExistence(Long issueId) {
-        return issueRepository.existsById(issueId);
-    }
-
     public IssueDetailResponse findIssueDetail(Long issueId) {
 
         IssueDetailResponse issueDetailResponse = issueRepository.findIssueDetail(issueId)

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -19,11 +19,6 @@ public class IssueQueryService {
 
     private final IssueRepository issueRepository;
 
-    public Issue findIssue(Long issueId) {
-        return issueRepository.findById(issueId)
-                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
-    }
-
     public List<Issue> findIssues(List<Long> issueIds) {
         return issueRepository.findAllById(issueIds);
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -49,4 +49,9 @@ public class IssueQueryService {
 
         return issueDetailResponse;
     }
+
+    public Issue findByIdWithAuthorAndMilestone(Long issueId) {
+        return issueRepository.findByIdWithAuthorAndMilestone(issueId)
+                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -19,6 +19,11 @@ public class IssueQueryService {
 
     private final IssueRepository issueRepository;
 
+    public Issue findIssueById(Long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈가 존재하지 않습니다."));
+    }
+
     public List<Issue> findIssues(List<Long> issueIds) {
         return issueRepository.findAllById(issueIds);
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -35,7 +35,7 @@ public class IssueQueryService {
     }
 
     public Issue findDetailIssue(Long issueId) {
-        Issue detailIssue = issueRepository.findDetailIssueById(issueId)
+        Issue detailIssue = issueRepository.findByIdWithAuthorAndMilestone(issueId)
                 .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
 
 

--- a/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/issue/IssueQueryService.java
@@ -3,7 +3,11 @@ package com.codesquad.issuetracker.service.issue;
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.excption.IssueNotFoundException;
 import com.codesquad.issuetracker.repository.issue.IssueRepository;
+import com.codesquad.issuetracker.service.comment.CommentQueryService;
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
+import com.codesquad.issuetracker.web.dto.issue.IssueAssigneeDto;
 import com.codesquad.issuetracker.web.dto.issue.IssueDetailResponse;
+import com.codesquad.issuetracker.web.dto.issue.IssueLabelDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,8 @@ public class IssueQueryService {
 
     private final IssueRepository issueRepository;
 
+    private final CommentQueryService commentQueryService;
+
     public Issue findIssueById(Long issueId) {
         return issueRepository.findById(issueId)
                 .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈가 존재하지 않습니다."));
@@ -32,8 +38,19 @@ public class IssueQueryService {
         return issueRepository.existsById(issueId);
     }
 
-    public IssueDetailResponse findDetailIssue(Long issueId) {
-        return issueRepository.findIssueDetail(issueId)
-                .orElseThrow(()-> new IssueNotFoundException("일치하는 식별자의 이슈를 찾을 수 없습니다."));
+    public IssueDetailResponse findIssueDetail(Long issueId) {
+
+        IssueDetailResponse issueDetailResponse = issueRepository.findIssueDetail(issueId)
+                .orElseThrow(() -> new IssueNotFoundException("일치하는 식별자의 이슈가 존재하지 않습니다."));
+
+        List<IssueAssigneeDto> assigneeDtos = issueRepository.findIssueAssigneeDtosByIssueId(issueId);
+        List<IssueLabelDto> issueLabelDtos = issueRepository.findIssueLabelDtosByIssueId(issueId);
+        List<CommentListElement> commentDtos = commentQueryService.findCommentDtosByIssueId(issueId);
+
+        issueDetailResponse.getAssignees().addAll(assigneeDtos);
+        issueDetailResponse.getLabels().addAll(issueLabelDtos);
+        issueDetailResponse.getComments().addAll(commentDtos);
+
+        return issueDetailResponse;
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
@@ -1,0 +1,14 @@
+package com.codesquad.issuetracker.service.label;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LabelCommandService {
+
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
@@ -2,6 +2,7 @@ package com.codesquad.issuetracker.service.label;
 
 import com.codesquad.issuetracker.domain.Label;
 import com.codesquad.issuetracker.repository.label.LabelRepository;
+import com.codesquad.issuetracker.web.dto.label.LabelCreateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,7 +16,8 @@ public class LabelCommandService {
 
     private final LabelRepository labelRepository;
 
-    public Long enrollLabel(Label label) {
+    public Long createLabel(LabelCreateRequest labelCreateRequest) {
+        Label label = labelCreateRequest.toEntity();
         labelRepository.save(label);
         return label.getId();
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelCommandService.java
@@ -1,5 +1,7 @@
 package com.codesquad.issuetracker.service.label;
 
+import com.codesquad.issuetracker.domain.Label;
+import com.codesquad.issuetracker.repository.label.LabelRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,4 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LabelCommandService {
 
+    private final LabelRepository labelRepository;
+
+    public Long enrollLabel(Label label) {
+        labelRepository.save(label);
+        return label.getId();
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelQueryService.java
@@ -1,9 +1,14 @@
 package com.codesquad.issuetracker.service.label;
 
+import com.codesquad.issuetracker.domain.Label;
+import com.codesquad.issuetracker.repository.label.LabelRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
 
 @Slf4j
 @Service
@@ -11,4 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LabelQueryService {
 
+    private final LabelRepository labelRepository;
+
+    public List<Label> findAllById(List<Long> labelIds) {
+        return labelRepository.findAllById(labelIds);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/label/LabelQueryService.java
@@ -1,0 +1,14 @@
+package com.codesquad.issuetracker.service.label;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LabelQueryService {
+
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/service/member/MemberQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/member/MemberQueryService.java
@@ -1,10 +1,14 @@
 package com.codesquad.issuetracker.service.member;
 
+import com.codesquad.issuetracker.domain.Member;
+import com.codesquad.issuetracker.excption.MemberNotFoundException;
 import com.codesquad.issuetracker.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Slf4j
@@ -15,4 +19,12 @@ public class MemberQueryService {
 
     private final MemberRepository memberRepository;
 
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("일치하는 식별자의 회원이 존재하지 않습니다."));
+    }
+
+    public List<Member> findAllById(List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/service/milestone/MilestoneQueryService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/service/milestone/MilestoneQueryService.java
@@ -1,0 +1,25 @@
+package com.codesquad.issuetracker.service.milestone;
+
+import com.codesquad.issuetracker.domain.Milestone;
+import com.codesquad.issuetracker.excption.MilestoneNotFoundException;
+import com.codesquad.issuetracker.repository.milestone.MilestoneRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MilestoneQueryService {
+
+    private final MilestoneRepository milestoneRepository;
+
+    public Milestone findMilestoneById(Long milestoneId) {
+        return (milestoneId == null)
+                ? null
+                : milestoneRepository.findById(milestoneId)
+                .orElseThrow(() -> new MilestoneNotFoundException("일치하는 식별자의 마일스톤이 존재하지 않습니다."));
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -65,8 +65,7 @@ public class IssueController {
     @GetMapping("/issue-tracker/api/issues/{issueId}")
     public IssueDetailResponse issueDetail(@PathVariable Long issueId) {
         log.info("Issue Detail Request - issueId = {}", issueId);
-        Issue issue = issueQueryService.findDetailIssue(issueId);
-        return IssueDetailResponse.create(issue);
+        return issueQueryService.findDetailIssue(issueId);
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -35,7 +35,7 @@ public class IssueController {
                 createRequest.getLabelIds(),
                 createRequest.getTitle(),
                 createRequest.getContent());
-        
+
         log.info("Created Issue Id = {}", createdIssueId);
         return new IssueCreateResponse(createdIssueId);
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -67,7 +67,7 @@ public class IssueController {
     @GetMapping("/issue-tracker/api/issues/{issueId}")
     public IssueDetailResponse issueDetail(@PathVariable Long issueId) {
         log.info("Issue Detail Request - issueId = {}", issueId);
-        return issueQueryService.findDetailIssue(issueId);
+        return issueQueryService.findIssueDetail(issueId);
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -75,11 +75,12 @@ public class IssueController {
      */
     @PatchMapping("/issue-tracker/api/issues/{issueId}")
     public IssueStateChangeResponse stateChange(@PathVariable Long issueId, @RequestBody IssueStateChangeRequest stateChangeRequest) {
-        boolean isOpened = stateChangeRequest.getIsOpened();
-        log.info("Issue StateChange Request = {}", isOpened);
+        log.info("Issue StateChange Request = {}", stateChangeRequest);
 
-        issueCommandService.changeState(issueId, isOpened);
-        return new IssueStateChangeResponse(issueId, isOpened);
+        issueCommandService.changeState(issueId, stateChangeRequest.getIsOpened());
+
+        Issue afterIssue = issueQueryService.findIssueById(issueId);
+        return IssueStateChangeResponse.create(afterIssue);
     }
 
     /**
@@ -104,10 +105,9 @@ public class IssueController {
     public MultipleIssueStateChangeResponse multipleStateChange(@RequestBody MultipleIssueStateChangeRequest multipleStateCahngeRequest) {
         log.info("Multiple Issue StateChange Request = {}", multipleStateCahngeRequest);
         issueCommandService.changeStates(multipleStateCahngeRequest.getIssueIds(), multipleStateCahngeRequest.getIsOpened());
-        List<Issue> issues = issueQueryService.findIssues(multipleStateCahngeRequest.getIssueIds());
 
-        return MultipleIssueStateChangeResponse.create(issues);
+        List<Issue> afterIssues = issueQueryService.findIssues(multipleStateCahngeRequest.getIssueIds());
+        return MultipleIssueStateChangeResponse.create(afterIssues);
     }
 
 }
-

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -52,10 +52,11 @@ public class IssueController {
     /**
      * 이슈 수정(제목, 본문, 레이블, 마일스톤)
      */
-    @PutMapping("/issue-tracker/api/issues")
-    public IssueUpdateResponse update(@RequestBody IssueUpdateRequest updateRequest) {
-        log.info("Issue Create Request = {}", updateRequest);
-        return null;
+    @PutMapping("/issue-tracker/api/issues/{issueId}")
+    public IssueUpdateResponse update(@PathVariable Long issueId, @RequestBody IssueUpdateRequest updateRequest) {
+        log.info("Issue update Request = {}", updateRequest);
+        issueCommandService.updateIssue(issueId, updateRequest);
+        return new IssueUpdateResponse(issueId);
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -6,6 +6,7 @@ import com.codesquad.issuetracker.service.issue.IssueQueryService;
 import com.codesquad.issuetracker.web.dto.issue.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,6 +25,7 @@ public class IssueController {
      * 이슈 생성
      */
     @PostMapping("/issue-tracker/api/issues")
+    @ResponseStatus(HttpStatus.CREATED)
     public IssueCreateResponse create(@RequestBody IssueCreateRequest createRequest) {
         log.info("Issue Create Request = {}", createRequest);
         Long authorId = SAMPLE_MEMBER_ID;
@@ -84,6 +86,7 @@ public class IssueController {
      * 이슈 삭제
      */
     @DeleteMapping("/issue-tracker/api/issues/{issueId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public IssueDeleteResponse delete(@PathVariable Long issueId) {
         log.info("Issue Delete Request - issueId = {}", issueId);
         issueCommandService.deleteIssue(issueId);

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -7,8 +7,10 @@ import com.codesquad.issuetracker.web.dto.issue.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Slf4j
@@ -87,14 +89,10 @@ public class IssueController {
      * 이슈 삭제
      */
     @DeleteMapping("/issue-tracker/api/issues/{issueId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public IssueDeleteResponse delete(@PathVariable Long issueId) {
+    @ResponseStatus(HttpStatus.OK)
+    public IssueDeleteResponse delete(@PathVariable @NotNull Long issueId) {
         log.info("Issue Delete Request - issueId = {}", issueId);
-        issueCommandService.deleteIssue(issueId);
-
-        boolean isDeleted = !issueQueryService.checkIssueExistence(issueId);
-        log.info("Is issue deleted? = {}", isDeleted);
-
+        boolean isDeleted = issueCommandService.deleteIssue(issueId);
         return new IssueDeleteResponse(isDeleted);
     }
 

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -73,11 +73,11 @@ public class IssueController {
      */
     @PatchMapping("/issue-tracker/api/issues/{issueId}")
     public IssueStateChangeResponse stateChange(@PathVariable Long issueId, @RequestBody IssueStateChangeRequest stateChangeRequest) {
-        log.info("Issue StateChange Request = {}", stateChangeRequest);
-        issueCommandService.changeState(issueId, stateChangeRequest.getIsOpened());
-        Issue issue = issueQueryService.findIssue(issueId);
+        boolean isOpened = stateChangeRequest.getIsOpened();
+        log.info("Issue StateChange Request = {}", isOpened);
 
-        return IssueStateChangeResponse.create(issue);
+        issueCommandService.changeState(issueId, isOpened);
+        return new IssueStateChangeResponse(issueId, isOpened);
     }
 
     /**

--- a/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/IssueController.java
@@ -3,7 +3,7 @@ package com.codesquad.issuetracker.web;
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.service.issue.IssueCommandService;
 import com.codesquad.issuetracker.service.issue.IssueQueryService;
-import com.codesquad.issuetracker.web.dto.*;
+import com.codesquad.issuetracker.web.dto.issue.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
@@ -7,8 +7,10 @@ import com.codesquad.issuetracker.web.dto.label.LabelCreateRequest;
 import com.codesquad.issuetracker.web.dto.label.LabelCreateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -20,6 +22,7 @@ public class LabelController {
     private final LabelCommandService labelCommandService;
 
     @PostMapping("/issue-tracker/api/labels")
+    @ResponseStatus(HttpStatus.CREATED)
     public LabelCreateResponse createLabel(@RequestBody LabelCreateRequest labelCreateRequest) {
         Label label = labelCreateRequest.toEntity();
         Long labelId = labelCommandService.enrollLabel(label);

--- a/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
@@ -1,0 +1,31 @@
+package com.codesquad.issuetracker.web;
+
+import com.codesquad.issuetracker.domain.Label;
+import com.codesquad.issuetracker.service.label.LabelCommandService;
+import com.codesquad.issuetracker.service.label.LabelQueryService;
+import com.codesquad.issuetracker.web.dto.label.LabelCreateRequest;
+import com.codesquad.issuetracker.web.dto.label.LabelCreateResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class LabelController {
+
+    private final LabelQueryService labelQueryService;
+    private final LabelCommandService labelCommandService;
+
+    @PostMapping("/issue-tracker/api/labels")
+    public LabelCreateResponse createLabel(@RequestBody LabelCreateRequest labelCreateRequest) {
+        Label label = labelCreateRequest.toEntity();
+        Long labelId = labelCommandService.enrollLabel(label);
+
+        log.info("create Label = {}", label);
+
+        return new LabelCreateResponse(labelId);
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/LabelController.java
@@ -1,6 +1,5 @@
 package com.codesquad.issuetracker.web;
 
-import com.codesquad.issuetracker.domain.Label;
 import com.codesquad.issuetracker.service.label.LabelCommandService;
 import com.codesquad.issuetracker.service.label.LabelQueryService;
 import com.codesquad.issuetracker.web.dto.label.LabelCreateRequest;
@@ -24,11 +23,8 @@ public class LabelController {
     @PostMapping("/issue-tracker/api/labels")
     @ResponseStatus(HttpStatus.CREATED)
     public LabelCreateResponse createLabel(@RequestBody LabelCreateRequest labelCreateRequest) {
-        Label label = labelCreateRequest.toEntity();
-        Long labelId = labelCommandService.enrollLabel(label);
-
-        log.info("create Label = {}", label);
-
+        Long labelId = labelCommandService.createLabel(labelCreateRequest);
+        log.info("create Label = {}", labelId);
         return new LabelCreateResponse(labelId);
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/comment/CommentListElement.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/comment/CommentListElement.java
@@ -1,0 +1,27 @@
+package com.codesquad.issuetracker.web.dto.comment;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentListElement {
+
+    private Long commentId;
+    private Long commentAuthorId;
+    private String commentAuthorName;
+    private String commentContent;
+    private LocalDateTime commentCreatedTime;
+    private LocalDateTime commentLastModifiedTime;
+
+    @QueryProjection
+    public CommentListElement(Long commentId, Long commentAuthorId, String commentAuthorName, String commentContent, LocalDateTime commentCreatedTime, LocalDateTime commentLastModifiedTime) {
+        this.commentId = commentId;
+        this.commentAuthorId = commentAuthorId;
+        this.commentAuthorName = commentAuthorName;
+        this.commentContent = commentContent;
+        this.commentCreatedTime = commentCreatedTime;
+        this.commentLastModifiedTime = commentLastModifiedTime;
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/comment/CommentListElement.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/comment/CommentListElement.java
@@ -8,12 +8,12 @@ import java.time.LocalDateTime;
 @Getter
 public class CommentListElement {
 
-    private Long commentId;
-    private Long commentAuthorId;
-    private String commentAuthorName;
-    private String commentContent;
-    private LocalDateTime commentCreatedTime;
-    private LocalDateTime commentLastModifiedTime;
+    private final Long commentId;
+    private final Long commentAuthorId;
+    private final String commentAuthorName;
+    private final String commentContent;
+    private final LocalDateTime commentCreatedTime;
+    private final LocalDateTime commentLastModifiedTime;
 
     @QueryProjection
     public CommentListElement(Long commentId, Long commentAuthorId, String commentAuthorName, String commentContent, LocalDateTime commentCreatedTime, LocalDateTime commentLastModifiedTime) {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueAssigneeDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueAssigneeDto.java
@@ -1,0 +1,17 @@
+package com.codesquad.issuetracker.web.dto.issue;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class IssueAssigneeDto {
+
+    private Long assigneeId;
+    private String assigneeName;
+
+    @QueryProjection
+    public IssueAssigneeDto(Long assigneeId, String assigneeName) {
+        this.assigneeId = assigneeId;
+        this.assigneeName = assigneeName;
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueAssigneeDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueAssigneeDto.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 public class IssueAssigneeDto {
 
-    private Long assigneeId;
-    private String assigneeName;
+    private final Long assigneeId;
+    private final String assigneeName;
 
     @QueryProjection
     public IssueAssigneeDto(Long assigneeId, String assigneeName) {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateRequest.java
@@ -18,6 +18,6 @@ public class IssueCreateRequest {
     private String title;
     private String content;
     private Long milestoneId;
-    private List<Long> labelIds = new ArrayList<>();
-    private List<Long> assigneeIds = new ArrayList<>();
+    private final List<Long> labelIds = new ArrayList<>();
+    private final List<Long> assigneeIds = new ArrayList<>();
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateRequest.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IssueUpdateRequest {
+public class IssueCreateRequest {
 
     @NotBlank
     private String title;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateResponse.java
@@ -5,10 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssueCreateResponse {
 
-    private Long issueId;
+    private final Long issueId;
 
     public IssueCreateResponse(Long issueId) {
         this.issueId = issueId;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueCreateResponse.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IssueUpdateResponse {
+public class IssueCreateResponse {
 
     private Long issueId;
 
-    public IssueUpdateResponse(Long issueId) {
+    public IssueCreateResponse(Long issueId) {
         this.issueId = issueId;
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDeleteResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDeleteResponse.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDeleteResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDeleteResponse.java
@@ -1,12 +1,8 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssueDeleteResponse {
 
-    private boolean isDeleted;
+    private final boolean isDeleted;
 
     public IssueDeleteResponse(boolean isDeleted) {
         this.isDeleted = isDeleted;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
@@ -1,8 +1,8 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
+import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
 import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -39,41 +39,6 @@ public class IssueDetailResponse {
         this.isOpened = isOpened;
         this.createdAt = createdAt;
         this.lastModifiedAt = lastModifiedAt;
-    }
-
-    @Getter
-    public static class IssueAssigneeDto {
-
-        private Long assigneeId;
-        private String assigneeName;
-
-        @QueryProjection
-        public IssueAssigneeDto(Long assigneeId, String assigneeName) {
-            this.assigneeId = assigneeId;
-            this.assigneeName = assigneeName;
-        }
-    }
-
-    @Getter
-    public static class CommentListElement {
-
-        private Long commentId;
-        private Long commentAuthorId;
-        private String commentAuthorName;
-        private String commentContent;
-        private LocalDateTime commentCreatedTime;
-        private LocalDateTime commentLastModifiedTime;
-
-        @QueryProjection
-        public CommentListElement(Long commentId, Long commentAuthorId, String commentAuthorName, String commentContent, LocalDateTime commentCreatedTime, LocalDateTime commentLastModifiedTime) {
-            this.commentId = commentId;
-            this.commentAuthorId = commentAuthorId;
-            this.commentAuthorName = commentAuthorName;
-            this.commentContent = commentContent;
-            this.commentCreatedTime = commentCreatedTime;
-            this.commentLastModifiedTime = commentLastModifiedTime;
-        }
-
     }
 
     public Long getIssueId() {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
@@ -1,9 +1,10 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.Comment;
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.IssueAssignee;
 import com.codesquad.issuetracker.domain.IssueLabel;
+import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
@@ -1,21 +1,13 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
-import com.codesquad.issuetracker.domain.Comment;
-import com.codesquad.issuetracker.domain.Issue;
-import com.codesquad.issuetracker.domain.IssueAssignee;
-import com.codesquad.issuetracker.domain.IssueLabel;
 import com.codesquad.issuetracker.web.dto.label.LabelDto;
-import lombok.AccessLevel;
-import lombok.Builder;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssueDetailResponse {
 
     private Long issueId;
@@ -23,87 +15,47 @@ public class IssueDetailResponse {
     private String authorName;
     private String title;
     private String content;
-    private List<IssueAssigneeDto> assignees = new ArrayList<>();
+    private final List<IssueAssigneeDto> assignees = new ArrayList<>();
     private Long milestoneId;
     private String milestoneName;
     private boolean isOpened;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
-    private List<LabelDto> labels = new ArrayList<>();
-    private List<CommentListElement> comments = new ArrayList<>();
+    private final List<LabelDto> labels = new ArrayList<>();
+    private final List<CommentListElement> comments = new ArrayList<>();
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private IssueDetailResponse(Long issueId, Long authorId, String authorName, String title, String content, List<IssueAssigneeDto> assignees, Long milestoneId, String milestoneName, boolean isOpened, LocalDateTime createdAt, LocalDateTime lastModifiedAt, List<LabelDto> labels, List<CommentListElement> comments) {
+    @QueryProjection
+    public IssueDetailResponse(
+            Long issueId, Long authorId, String authorName,
+            String title, String content, Long milestoneId, String milestoneName,
+            boolean isOpened, LocalDateTime createdAt, LocalDateTime lastModifiedAt) {
         this.issueId = issueId;
         this.authorId = authorId;
         this.authorName = authorName;
         this.title = title;
         this.content = content;
-        this.assignees = assignees;
         this.milestoneId = milestoneId;
         this.milestoneName = milestoneName;
         this.isOpened = isOpened;
         this.createdAt = createdAt;
         this.lastModifiedAt = lastModifiedAt;
-        this.labels = labels;
-        this.comments = comments;
-    }
-
-    public static IssueDetailResponse create(Issue issue) {
-        return IssueDetailResponse.builder()
-                .issueId(issue.getId())
-                .authorId(issue.getAuthor().getId())
-                .authorName(issue.getAuthor().getName())
-                .title(issue.getTitle())
-                .content(issue.getContent())
-                .assignees(initAssignees(issue))
-                .milestoneId(issue.getMilestone().getId())
-                .milestoneName(issue.getMilestone().getTitle())
-                .isOpened(issue.isOpened())
-                .createdAt(issue.getCreatedAt())
-                .lastModifiedAt(issue.getLastModifiedAt())
-                .labels(initLabels(issue))
-                .comments(initComments(issue))
-                .build();
-    }
-
-    private static List<IssueAssigneeDto> initAssignees(Issue issue) {
-        return issue.getAssignees().stream()
-                .map(IssueAssigneeDto::create)
-                .collect(Collectors.toList());
-    }
-
-    private static List<LabelDto> initLabels(Issue issue) {
-        return issue.getIssueLabels().stream()
-                .map(IssueLabel::getLabel)
-                .map(LabelDto::create)
-                .collect(Collectors.toList());
-    }
-
-    private static List<CommentListElement> initComments(Issue issue) {
-        return issue.getComments().stream()
-                .map(CommentListElement::create)
-                .collect(Collectors.toList());
     }
 
     @Getter
-    private static class IssueAssigneeDto {
+    public static class IssueAssigneeDto {
 
         private Long assigneeId;
         private String assigneeName;
 
-        private IssueAssigneeDto(Long assigneeId, String assigneeName) {
+        @QueryProjection
+        public IssueAssigneeDto(Long assigneeId, String assigneeName) {
             this.assigneeId = assigneeId;
             this.assigneeName = assigneeName;
-        }
-
-        public static IssueAssigneeDto create(IssueAssignee issueAssignee) {
-            return new IssueAssigneeDto(issueAssignee.getId(), issueAssignee.getMember().getName());
         }
     }
 
     @Getter
-    private static class CommentListElement {
+    public static class CommentListElement {
 
         private Long commentId;
         private Long commentAuthorId;
@@ -112,8 +64,8 @@ public class IssueDetailResponse {
         private LocalDateTime commentCreatedTime;
         private LocalDateTime commentLastModifiedTime;
 
-        @Builder(access = AccessLevel.PRIVATE)
-        private CommentListElement(Long commentId, Long commentAuthorId, String commentAuthorName, String commentContent, LocalDateTime commentCreatedTime, LocalDateTime commentLastModifiedTime) {
+        @QueryProjection
+        public CommentListElement(Long commentId, Long commentAuthorId, String commentAuthorName, String commentContent, LocalDateTime commentCreatedTime, LocalDateTime commentLastModifiedTime) {
             this.commentId = commentId;
             this.commentAuthorId = commentAuthorId;
             this.commentAuthorName = commentAuthorName;
@@ -122,16 +74,6 @@ public class IssueDetailResponse {
             this.commentLastModifiedTime = commentLastModifiedTime;
         }
 
-        public static CommentListElement create(Comment comment) {
-            return CommentListElement.builder()
-                    .commentId(comment.getId())
-                    .commentAuthorId(comment.getAuthor().getId())
-                    .commentAuthorName(comment.getAuthor().getName())
-                    .commentContent(comment.getContent())
-                    .commentCreatedTime(comment.getCreatedAt())
-                    .commentLastModifiedTime(comment.getLastModifiedAt())
-                    .build();
-        }
     }
 
     public Long getIssueId() {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
@@ -1,7 +1,6 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.web.dto.comment.CommentListElement;
-import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import com.querydsl.core.annotations.QueryProjection;
 
 import java.time.LocalDateTime;
@@ -21,7 +20,7 @@ public class IssueDetailResponse {
     private boolean isOpened;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
-    private final List<LabelDto> labels = new ArrayList<>();
+    private final List<IssueLabelDto> labels = new ArrayList<>();
     private final List<CommentListElement> comments = new ArrayList<>();
 
     @QueryProjection
@@ -85,7 +84,7 @@ public class IssueDetailResponse {
         return lastModifiedAt;
     }
 
-    public List<LabelDto> getLabels() {
+    public List<IssueLabelDto> getLabels() {
         return labels;
     }
 

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueDetailResponse.java
@@ -9,17 +9,17 @@ import java.util.List;
 
 public class IssueDetailResponse {
 
-    private Long issueId;
-    private Long authorId;
-    private String authorName;
-    private String title;
-    private String content;
+    private final Long issueId;
+    private final Long authorId;
+    private final String authorName;
+    private final String title;
+    private final String content;
     private final List<IssueAssigneeDto> assignees = new ArrayList<>();
-    private Long milestoneId;
-    private String milestoneName;
-    private boolean isOpened;
-    private LocalDateTime createdAt;
-    private LocalDateTime lastModifiedAt;
+    private final Long milestoneId;
+    private final String milestoneName;
+    private final boolean isOpened;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime lastModifiedAt;
     private final List<IssueLabelDto> labels = new ArrayList<>();
     private final List<CommentListElement> comments = new ArrayList<>();
 

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueLabelDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueLabelDto.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @Getter
 public class IssueLabelDto {
 
-    private Long labelId;
-    private String labelName;
-    private String labelColor;
+    private final Long labelId;
+    private final String labelName;
+    private final String labelColor;
 
     @QueryProjection
     public IssueLabelDto(Long labelId, String labelName, LabelColor labelColor) {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueLabelDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueLabelDto.java
@@ -1,18 +1,18 @@
-package com.codesquad.issuetracker.web.dto.label;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.LabelColor;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 @Getter
-public class LabelDto {
+public class IssueLabelDto {
 
     private Long labelId;
     private String labelName;
     private String labelColor;
 
     @QueryProjection
-    public LabelDto(Long labelId, String labelName, LabelColor labelColor) {
+    public IssueLabelDto(Long labelId, String labelName, LabelColor labelColor) {
         this.labelId = labelId;
         this.labelName = labelName;
         this.labelColor = labelColor.getColorCode();

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 @ToString
 public class IssueListRequest {
 
-    private boolean isOpened;
+    private final boolean isOpened;
 
     public IssueListRequest(boolean isOpened) {
         this.isOpened = isOpened;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListRequest.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
@@ -2,7 +2,6 @@ package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.IssueLabel;
-import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,10 +26,10 @@ public class IssueListResponse {
         private String content;
         private Long milestoneId;
         private String milestoneName;
-        private List<LabelDto> labels = new ArrayList<>();
+        private List<IssueLabelDto> labels = new ArrayList<>();
 
         @Builder(access = AccessLevel.PRIVATE)
-        private IssueListElement(Long issueId, String title, String content, Long milestoneId, String milestoneName, List<LabelDto> labels) {
+        private IssueListElement(Long issueId, String title, String content, Long milestoneId, String milestoneName, List<IssueLabelDto> labels) {
             this.issueId = issueId;
             this.title = title;
             this.content = content;
@@ -59,10 +58,10 @@ public class IssueListResponse {
             return issue.getMilestone() == null ? null : issue.getMilestone().getTitle();
         }
 
-        private static List<LabelDto> initLabels(Issue issue) {
+        private static List<IssueLabelDto> initLabels(Issue issue) {
             return issue.getIssueLabels().stream()
                     .map(IssueLabel::getLabel)
-                    .map(label -> new LabelDto(label.getId(), label.getName(), label.getLabelColor()))
+                    .map(label -> new IssueLabelDto(label.getId(), label.getName(), label.getLabelColor()))
                     .collect(Collectors.toList());
         }
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
@@ -1,7 +1,8 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import com.codesquad.issuetracker.domain.IssueLabel;
+import com.codesquad.issuetracker.web.dto.label.LabelDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueListResponse.java
@@ -62,7 +62,7 @@ public class IssueListResponse {
         private static List<LabelDto> initLabels(Issue issue) {
             return issue.getIssueLabels().stream()
                     .map(IssueLabel::getLabel)
-                    .map(LabelDto::create)
+                    .map(label -> new LabelDto(label.getId(), label.getName(), label.getLabelColor()))
                     .collect(Collectors.toList());
         }
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeRequest.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
@@ -1,9 +1,8 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
@@ -4,8 +4,8 @@ import com.codesquad.issuetracker.domain.Issue;
 
 public class IssueStateChangeResponse {
 
-    private Long issueId;
-    private boolean isOpened;
+    private final Long issueId;
+    private final boolean isOpened;
 
     public static IssueStateChangeResponse create(Issue issue) {
         return new IssueStateChangeResponse(issue.getId(), issue.isOpened());

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
@@ -1,11 +1,17 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
+import com.codesquad.issuetracker.domain.Issue;
+
 public class IssueStateChangeResponse {
 
     private Long issueId;
     private boolean isOpened;
 
-    public IssueStateChangeResponse(Long issueId, boolean isOpened) {
+    public static IssueStateChangeResponse create(Issue issue) {
+        return new IssueStateChangeResponse(issue.getId(), issue.isOpened());
+    }
+
+    private IssueStateChangeResponse(Long issueId, boolean isOpened) {
         this.issueId = issueId;
         this.isOpened = isOpened;
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueStateChangeResponse.java
@@ -1,27 +1,13 @@
 package com.codesquad.issuetracker.web.dto.issue;
 
-import com.codesquad.issuetracker.domain.Issue;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssueStateChangeResponse {
 
     private Long issueId;
     private boolean isOpened;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private IssueStateChangeResponse(Long issueId, boolean isOpened) {
+    public IssueStateChangeResponse(Long issueId, boolean isOpened) {
         this.issueId = issueId;
         this.isOpened = isOpened;
-    }
-
-    public static IssueStateChangeResponse create(Issue issue) {
-        return IssueStateChangeResponse.builder()
-                .issueId(issue.getId())
-                .isOpened(issue.isOpened())
-                .build();
     }
 
     public Long getIssueId() {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IssueCreateRequest {
+public class IssueUpdateRequest {
 
     @NotBlank
     private String title;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateRequest.java
@@ -18,6 +18,6 @@ public class IssueUpdateRequest {
     private String title;
     private String content;
     private Long milestoneId;
-    private List<Long> labelIds = new ArrayList<>();
-    private List<Long> assigneeIds = new ArrayList<>();
+    private final List<Long> labelIds = new ArrayList<>();
+    private final List<Long> assigneeIds = new ArrayList<>();
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateResponse.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IssueCreateResponse {
+public class IssueUpdateResponse {
 
     private Long issueId;
 
-    public IssueCreateResponse(Long issueId) {
+    public IssueUpdateResponse(Long issueId) {
         this.issueId = issueId;
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/IssueUpdateResponse.java
@@ -5,10 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssueUpdateResponse {
 
-    private Long issueId;
+    private final Long issueId;
 
     public IssueUpdateResponse(Long issueId) {
         this.issueId = issueId;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeRequest.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeRequest.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MultipleIssueStateChangeRequest {
 
-    private List<Long> issueIds = new ArrayList<>();
+    private final List<Long> issueIds = new ArrayList<>();
     private boolean isOpened;
 
     public List<Long> getIssueIds() {

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MultipleIssueStateChangeResponse {
 
-    private List<IssueStateChangeResponse> patchedIssues = new ArrayList<>();
+    private final List<IssueStateChangeResponse> patchedIssues = new ArrayList<>();
 
     public static MultipleIssueStateChangeResponse create(List<Issue> issues) {
         List<IssueStateChangeResponse> patchedIssues = issues.stream()
@@ -24,7 +24,7 @@ public class MultipleIssueStateChangeResponse {
     }
 
     private MultipleIssueStateChangeResponse(List<IssueStateChangeResponse> patchedIssues) {
-        this.patchedIssues = patchedIssues;
+        this.patchedIssues.addAll(patchedIssues);
     }
 
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
@@ -22,7 +22,7 @@ public class MultipleIssueStateChangeResponse {
     public static MultipleIssueStateChangeResponse create(List<Issue> issues) {
 
         List<IssueStateChangeResponse> patchedIssues = issues.stream()
-                .map(IssueStateChangeResponse::create)
+                .map(issue -> new IssueStateChangeResponse(issue.getId(), issue.isOpened()))
                 .collect(Collectors.toList());
 
         return new MultipleIssueStateChangeResponse(patchedIssues);

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.issue;
 
 import com.codesquad.issuetracker.domain.Issue;
 import lombok.AccessLevel;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/issue/MultipleIssueStateChangeResponse.java
@@ -15,16 +15,16 @@ public class MultipleIssueStateChangeResponse {
 
     private List<IssueStateChangeResponse> patchedIssues = new ArrayList<>();
 
-    private MultipleIssueStateChangeResponse(List<IssueStateChangeResponse> patchedIssues) {
-        this.patchedIssues = patchedIssues;
-    }
-
     public static MultipleIssueStateChangeResponse create(List<Issue> issues) {
-
         List<IssueStateChangeResponse> patchedIssues = issues.stream()
-                .map(issue -> new IssueStateChangeResponse(issue.getId(), issue.isOpened()))
+                .map(IssueStateChangeResponse::create)
                 .collect(Collectors.toList());
 
         return new MultipleIssueStateChangeResponse(patchedIssues);
     }
+
+    private MultipleIssueStateChangeResponse(List<IssueStateChangeResponse> patchedIssues) {
+        this.patchedIssues = patchedIssues;
+    }
+
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateRequest.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateRequest.java
@@ -1,0 +1,26 @@
+package com.codesquad.issuetracker.web.dto.label;
+
+import com.codesquad.issuetracker.domain.Label;
+import com.codesquad.issuetracker.domain.LabelColor;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LabelCreateRequest {
+
+    @NotBlank
+    private String name;
+    private String description;
+    private String colorCode;
+
+    public Label toEntity() {
+        LabelColor labelColor = LabelColor.create(colorCode);
+        return new Label(name, description, labelColor);
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateResponse.java
@@ -1,0 +1,16 @@
+package com.codesquad.issuetracker.web.dto.label;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LabelCreateResponse {
+
+    private Long labelId;
+
+    public LabelCreateResponse(Long labelId) {
+        this.labelId = labelId;
+    }
+}

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateResponse.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelCreateResponse.java
@@ -5,10 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LabelCreateResponse {
 
-    private Long labelId;
+    private final Long labelId;
 
     public LabelCreateResponse(Long labelId) {
         this.labelId = labelId;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelDto.java
@@ -1,4 +1,4 @@
-package com.codesquad.issuetracker.web.dto;
+package com.codesquad.issuetracker.web.dto.label;
 
 import com.codesquad.issuetracker.domain.Label;
 import lombok.AccessLevel;

--- a/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelDto.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/web/dto/label/LabelDto.java
@@ -1,31 +1,20 @@
 package com.codesquad.issuetracker.web.dto.label;
 
-import com.codesquad.issuetracker.domain.Label;
-import lombok.AccessLevel;
-import lombok.Builder;
+import com.codesquad.issuetracker.domain.LabelColor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LabelDto {
 
     private Long labelId;
     private String labelName;
     private String labelColor;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private LabelDto(Long labelId, String labelName, String labelColor) {
+    @QueryProjection
+    public LabelDto(Long labelId, String labelName, LabelColor labelColor) {
         this.labelId = labelId;
         this.labelName = labelName;
-        this.labelColor = labelColor;
-    }
-
-    public static LabelDto create(Label label) {
-        return LabelDto.builder()
-                .labelId(label.getId())
-                .labelName(label.getName())
-                .labelColor(label.getLabelColor().getColorCode())
-                .build();
+        this.labelColor = labelColor.getColorCode();
     }
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/IssuetrackerApplicationTests.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/IssuetrackerApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class IssuetrackerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/basic/HashSetTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/basic/HashSetTest.java
@@ -1,0 +1,33 @@
+package com.codesquad.issuetracker.basic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HashSetTest {
+
+    private final HashSet<String> hashSet = new HashSet<>();
+
+    @BeforeEach
+    void init() {
+        hashSet.clear();
+    }
+
+    @Test
+    @DisplayName("동등한 객체를 같은 HashSet에 삽입하면 먼저 삽입된 객체만 삽입된다.")
+    public void duplicateAddTest() {
+        String strA = new String("aaa");
+        String strB = new String("aaa");
+
+        hashSet.add(strA);
+        hashSet.add(strB);
+        String firstElement = hashSet.stream().findFirst().get();
+
+        assertThat(hashSet.size()).isEqualTo(1);
+        assertThat(firstElement).isSameAs(strA);
+    }
+}

--- a/BE/src/test/java/com/codesquad/issuetracker/basic/HashSetTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/basic/HashSetTest.java
@@ -30,4 +30,30 @@ public class HashSetTest {
         assertThat(hashSet.size()).isEqualTo(1);
         assertThat(firstElement).isSameAs(strA);
     }
+
+    @Test
+    @DisplayName("hashSet의 contains는 동등한 객체가 set에 있으면 true를 반환한다.")
+    public void containsTest() {
+        String strA = new String("aaa");
+        String strB = new String("aaa");
+
+        hashSet.add(strA);
+
+        boolean containsResult = hashSet.contains(strB);
+
+        assertThat(containsResult).isTrue();
+    }
+
+    @Test
+    @DisplayName("hashSet의 contains는 동등한 객체가 set에 없으면 false를 반환한다.")
+    public void notContainsTest() {
+        String strA = new String("aaa");
+        String strB = new String("bbb");
+
+        hashSet.add(strA);
+
+        boolean containsResult = hashSet.contains(strB);
+
+        assertThat(containsResult).isFalse();
+    }
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/basic/StringTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/basic/StringTest.java
@@ -1,0 +1,27 @@
+package com.codesquad.issuetracker.basic;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringTest {
+
+    @Test
+    @DisplayName("따로 생성된 String들의 주솟값은 다르다.")
+    public void notSameTest() {
+        String strA = new String("aaa");
+        String strB = new String("aaa");
+
+        assertThat(strA).isNotSameAs(strB);
+    }
+
+    @Test
+    @DisplayName("같은 문자열인 String 객체는 동등하다.")
+    public void equalsTest() {
+        String strA = new String("aaa");
+        String strB = new String("aaa");
+
+        assertThat(strA).isEqualTo(strB);
+    }
+}

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueAssigneeTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueAssigneeTest.java
@@ -1,0 +1,47 @@
+package com.codesquad.issuetracker.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IssueAssigneeTest {
+
+    private final Member memberA = new Member("memberA", "1234!", "사용자1");
+    private final Member memberB = new Member("memberB", "1234!", "사용자2");
+    private Issue issue;
+
+    @BeforeEach
+    void init() {
+        this.issue = Issue.create("냠냠", "본문", memberA, null);
+    }
+
+    @Test
+    @DisplayName("따로 생성된 IssueAssingee들은 주솟값이 다르다.")
+    public void notSameTest() {
+        IssueAssignee issueAssignee1 = new IssueAssignee(memberA, issue);
+        IssueAssignee issueAssignee2 = new IssueAssignee(memberA, issue);
+
+        assertThat(issueAssignee1).isNotSameAs(issueAssignee2);
+    }
+
+    @Test
+    @DisplayName("member, issue가 동등한 IssueAssignee는 동등하다.")
+    public void equalsTest() {
+        IssueAssignee issueAssignee1 = new IssueAssignee(memberA, issue);
+        IssueAssignee issueAssignee2 = new IssueAssignee(memberA, issue);
+
+        assertThat(issueAssignee1).isEqualTo(issueAssignee2);
+    }
+
+    @Test
+    @DisplayName("member 또는 issue가 동등하지 않은 IssueAssignee는 동등하지 않다.")
+    public void notEqualsTest() throws Exception {
+        IssueAssignee issueAssignee1 = new IssueAssignee(memberA, issue);
+        IssueAssignee issueAssignee2 = new IssueAssignee(memberB, issue);
+
+        assertThat(issueAssignee1).isNotEqualTo(issueAssignee2);
+    }
+
+}

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueAssigneeTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueAssigneeTest.java
@@ -44,4 +44,24 @@ class IssueAssigneeTest {
         assertThat(issueAssignee1).isNotEqualTo(issueAssignee2);
     }
 
+    @Test
+    @DisplayName("hasDiffrentIssue 메서드 호출 시, 자신의 이슈와 다른 이슈면 true를 반환한다.")
+    public void hasDifferentIssueTest_True() {
+        IssueAssignee issueAssignee = new IssueAssignee(memberA, issue);
+
+        Issue otherIssue = Issue.create("Other Issue", "content", memberA, null);
+
+        boolean result = issueAssignee.hasDifferentIssue(otherIssue);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasDiffrentIssue 메서드 호출 시, 자신의 이슈와 동등한 이슈면 false를 반환한다.")
+    public void hasDifferentIssueTest_False() {
+        IssueAssignee issueAssignee = new IssueAssignee(memberA, issue);
+        boolean result = issueAssignee.hasDifferentIssue(issue);
+
+        assertThat(result).isFalse();
+    }
+
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueLabelTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueLabelTest.java
@@ -1,0 +1,49 @@
+package com.codesquad.issuetracker.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class IssueLabelTest {
+
+    private final Label labelA = new Label("labelA", "widwdniw", LabelColor.create("FFFFFF"));
+    private final Label labelB = new Label("labelB", "widwdniw", LabelColor.create("AAAAAA"));
+    private final Member author = new Member("test", "1234", "github");
+
+    private Issue issue;
+
+    @BeforeEach
+    void init() {
+        this.issue = Issue.create("냠냠", "본문", author, null);
+    }
+
+    @Test
+    @DisplayName("따로 생성된 IssueLabel들은 주솟값이 다르다.")
+    public void notSameTest() {
+        IssueLabel issueLabelA = new IssueLabel(labelA, issue);
+        IssueLabel issueLabelB = new IssueLabel(labelA, issue);
+
+        assertThat(issueLabelA).isNotSameAs(issueLabelB);
+    }
+
+    @Test
+    @DisplayName("label, issue가 동등한 IssueLabel은 동등하다.")
+    public void equalsTest() {
+        IssueLabel issueLabelA = new IssueLabel(labelA, issue);
+        IssueLabel issueLabelB = new IssueLabel(labelA, issue);
+
+        assertThat(issueLabelA).isEqualTo(issueLabelB);
+    }
+
+    @Test
+    @DisplayName("label 또는 issue가 동등하지 않은 IssueLabel은 동등하지 않다.")
+    public void notEqualsTest() throws Exception {
+        IssueLabel issueLabelA = new IssueLabel(labelA, issue);
+        IssueLabel issueLabelB = new IssueLabel(labelB, issue);
+
+        assertThat(issueLabelA).isNotEqualTo(issueLabelB);
+    }
+}

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueLabelTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueLabelTest.java
@@ -46,4 +46,24 @@ class IssueLabelTest {
 
         assertThat(issueLabelA).isNotEqualTo(issueLabelB);
     }
+
+    @Test
+    @DisplayName("hasDiffrentIssue 메서드 호출 시, 자신의 이슈와 다른 이슈면 true를 반환한다.")
+    public void hasDifferentIssueTest_True() {
+        IssueLabel issueLabel = new IssueLabel(labelA, issue);
+
+        Issue otherIssue = Issue.create("Other Issue", "content", author, null);
+
+        boolean result = issueLabel.hasDifferentIssue(otherIssue);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasDiffrentIssue 메서드 호출 시, 자신의 이슈와 동등한 이슈면 false를 반환한다.")
+    public void hasDifferentIssueTest_False() {
+        IssueLabel issueLabel = new IssueLabel(labelA, issue);
+
+        boolean result = issueLabel.hasDifferentIssue(issue);
+        assertThat(result).isFalse();
+    }
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueTest.java
@@ -2,31 +2,35 @@ package com.codesquad.issuetracker.domain;
 
 import com.codesquad.issuetracker.excption.InvalidIssueAssigneeAddException;
 import com.codesquad.issuetracker.excption.InvalidIssueLabelAddException;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
+@Slf4j
 class IssueTest {
 
-    private final Member memberA = new Member("memberA", "1234!", "사용자1");
-    private final Member memberB = new Member("memberB", "1234!", "사용자2");
-    private final Label labelA = new Label("labelA", "widwdniw", LabelColor.create("FFFFFF"));
-    private final Label labelB = new Label("labelB", "widwdniw", LabelColor.create("AAAAAA"));
-    private Issue issue;
-    private Set<IssueAssignee> issueAssignees;
-    private Set<IssueLabel> issueLabels;
+    Member memberA = new Member("memberA", "1234!", "사용자1");
+    Member memberB = new Member("memberB", "1234!", "사용자2");
+    Label labelA = new Label("labelA", "widwdniw", LabelColor.create("FFFFFF"));
+    Label labelB = new Label("labelB", "widwdniw", LabelColor.create("AAAAAA"));
+
+    Issue issue = issue = Issue.create("냠냠", "본문", memberA, null);
+
+    Set<IssueAssignee> issueAssignees = issue.getAssignees();
+    Set<IssueLabel> issueLabels = issue.getIssueLabels();
 
 
     @BeforeEach
     void init() {
-        issue = Issue.create("냠냠", "본문", memberA, null);
-        issueAssignees = issue.getAssignees();
-        issueLabels = issue.getIssueLabels();
+        issueAssignees.clear();
+        issueLabels.clear();
     }
 
     @Test
@@ -105,5 +109,98 @@ class IssueTest {
                 .isInstanceOf(InvalidIssueLabelAddException.class);
     }
 
+    @Nested
+    @DisplayName("removeAssigneesNotIn 메서드는")
+    class removeAssigneesNotIn_메서드는 {
 
+        @Nested
+        @DisplayName("기존 이슈 Assignee가 인자에 포함되지 않았을 때")
+        class 기존_이슈_Assignee_가_인자에_포함_안_될_때 {
+
+            IssueAssignee beforeAssignee = new IssueAssignee(memberA, issue);
+            IssueAssignee otherAssignee = new IssueAssignee(memberB, issue);
+            List<IssueAssignee> otherIssueAssignees = List.of(otherAssignee);
+
+            @Test
+            @DisplayName("해당 IssueAssignee를 제거한다.")
+            public void deleteAssignee() {
+                issue.addIssueAssignee(beforeAssignee);
+
+                //when
+                issue.removeAssigneesNotIn(otherIssueAssignees);
+
+                assertThat(issueAssignees.size()).isEqualTo(0);
+                assertThat(issueAssignees).doesNotContain(beforeAssignee);
+            }
+        }
+
+        @Nested
+        @DisplayName("기존 이슈 Assignee가 인자에 포함될 때")
+        class 기존_이슈_Assignee_가_인자에_포함_될_때 {
+
+            IssueAssignee beforeAssignee = new IssueAssignee(memberA, issue);
+            IssueAssignee otherAssignee = new IssueAssignee(memberA, issue);
+            List<IssueAssignee> otherIssueAssignees = List.of(otherAssignee);
+
+            @Test
+            @DisplayName("해당 IssueAssignee를 제거하지 않는다.")
+            public void doesNotDeleteAssignee() {
+                // given
+                issue.addIssueAssignee(beforeAssignee);
+
+                // when
+                issue.removeAssigneesNotIn(otherIssueAssignees);
+
+                // then
+                assertThat(issueAssignees.size()).isEqualTo(1);
+                assertThat(issueAssignees).containsExactly(beforeAssignee);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("removeLabelsNotIn 메서드는")
+    class removeLablesNotIn_메서드는 {
+
+        @Nested
+        @DisplayName("기존 이슈 Labels가 인자에 포함되지 않았을 때")
+        class 기존_이슈_Labels_가_인자에_포함_안_될_때 {
+
+            IssueLabel beforeIssueLabel = new IssueLabel(labelA, issue);
+            IssueLabel otherIssueLabel = new IssueLabel(labelB, issue);
+            List<IssueLabel> otherIssueLabels = List.of(otherIssueLabel);
+
+            @Test
+            @DisplayName("해당 IssueLabel를 제거한다.")
+            public void deleteIssueLabel() {
+                issue.addIssueLabel(beforeIssueLabel);
+
+                //when
+                issue.removeIssueLabelsNotIn(otherIssueLabels);
+
+                assertThat(issueLabels.size()).isEqualTo(0);
+                assertThat(issueLabels).doesNotContain(beforeIssueLabel);
+            }
+        }
+
+        @Nested
+        @DisplayName("기존 이슈 Labels가 인자에 포함될 때")
+        class 기존_이슈_Labels_가_인자에_포함_될_때 {
+            IssueLabel beforeIssueLabel = new IssueLabel(labelA, issue);
+            IssueLabel otherIssueLabel = new IssueLabel(labelA, issue);
+            List<IssueLabel> otherIssueLabels = List.of(otherIssueLabel);
+
+            @Test
+            @DisplayName("해당 IssueLabel를 제거하지 않는다.")
+            public void doesNotDeleteIssueLabel() {
+                issue.addIssueLabel(beforeIssueLabel);
+
+                //when
+                issue.removeIssueLabelsNotIn(otherIssueLabels);
+
+                assertThat(issueLabels.size()).isEqualTo(1);
+                assertThat(issueLabels).containsExactly(beforeIssueLabel);
+            }
+        }
+    }
 }

--- a/BE/src/test/java/com/codesquad/issuetracker/domain/IssueTest.java
+++ b/BE/src/test/java/com/codesquad/issuetracker/domain/IssueTest.java
@@ -1,0 +1,64 @@
+package com.codesquad.issuetracker.domain;
+
+import com.codesquad.issuetracker.excption.InvalidIssueAssigneeAddException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IssueTest {
+
+    private final Member memberA = new Member("memberA", "1234!", "사용자1");
+    private final Member memberB = new Member("memberB", "1234!", "사용자2");
+    private Issue issue;
+    private Set<IssueAssignee> issueAssignees;
+
+    @BeforeEach
+    void init() {
+        issue = Issue.create("냠냠", "본문", memberA, null);
+        issueAssignees = issue.getAssignees();
+    }
+
+    @Test
+    @DisplayName("동등한 issueAssignee를 같은 issue에 삽입하면 먼저 삽입된 issueAssignee만 삽입된다.")
+    public void addEqualAssigneeTest() {
+        IssueAssignee issueAssigneeA = new IssueAssignee(memberA, issue);
+        IssueAssignee issueAssigneeB = new IssueAssignee(issueAssigneeA.getMember(), issueAssigneeA.getIssue());
+
+        issue.addIssueAssignee(issueAssigneeA);
+        issue.addIssueAssignee(issueAssigneeB);
+        IssueAssignee findIssueAssignee = issueAssignees.stream().findFirst().get();
+
+        assertThat(issue.getAssignees().size()).isEqualTo(1);
+        assertThat(issueAssigneeA).isNotSameAs(issueAssigneeB);
+        assertThat(findIssueAssignee).isSameAs(issueAssigneeA);
+    }
+
+    @Test
+    @DisplayName("동등하지 않은 issueAssignee를 같은 issue에 삽입하면 모두 다 삽입된다.")
+    public void addNotEqualAssigneeTest() {
+        IssueAssignee issueAssigneeA = new IssueAssignee(memberA, issue);
+        IssueAssignee issueAssigneeB = new IssueAssignee(memberB, issue);
+
+        issue.addIssueAssignee(issueAssigneeA);
+        issue.addIssueAssignee(issueAssigneeB);
+
+        assertThat(issue.getAssignees().size()).isEqualTo(2);
+        assertThat(issueAssignees).containsExactlyInAnyOrder(issueAssigneeA, issueAssigneeB);
+    }
+
+    @Test
+    @DisplayName("다른 이슈에 할당된 IssueAssignee를 issue에 할당하면 InvalidIssueAssigneeAddException이 발생한다.")
+    public void invalidIssueAssigneeAddTest() {
+        Issue otherIssue = Issue.create("Other Issue", "content", memberA, null);
+        IssueAssignee otherIssueAssignee = new IssueAssignee(memberB, otherIssue);
+
+        assertThatThrownBy(() -> issue.addIssueAssignee(otherIssueAssignee))
+                .isInstanceOf(InvalidIssueAssigneeAddException.class);
+    }
+
+}


### PR DESCRIPTION
안녕하세요 디온, 땃쥐 & 휘입니다!!
주문하신 스파게티가 나왔습니닷...!!!
주문이 늦어져서 죄송합니다ㅠㅠ 대신 미트볼을 추가해드렸습니다...:sob::sob::sob:

---

## 💻 주요 작업 내역

+ 이슈 생성 리팩토링
+ 이슈 수정
+ 이슈 다중상태 변경 최적화 : 쿼리 한번으로 하도록 함
+ 라벨 등록
+ 등록 시간과 수정 시간을 자동 갱신
+ 상세 조회 최적화

---

### 생성, 수정시각 공통화
![image](https://user-images.githubusercontent.com/88282356/175479489-b12d5631-15da-405b-b18c-a27f2cd0b30f.png)
- JPA Auditing을 활용하여 생성시각, 날짜를 공통화 처리했습니다.

---

### 상세조회 최적화
```java=
    @Override
    public Optional<IssueDetailResponse> findIssueDetail(Long issueId) {

        IssueDetailResponse issueDetailResponse = getIssueDetailResponse(issueId);

        if (issueDetailResponse == null) {
            return Optional.empty();
        }

        List<IssueDetailResponse.IssueAssigneeDto> assigneeDtos = findIssueAssigneeDtos(issueId);
        List<LabelDto> labelDtos = findLabelDtos(issueId);
        List<IssueDetailResponse.CommentListElement> commentDtos = findCommentDtos(issueId);

        issueDetailResponse.getAssignees().addAll(assigneeDtos);
        issueDetailResponse.getLabels().addAll(labelDtos);
        issueDetailResponse.getComments().addAll(commentDtos);

        return Optional.of(issueDetailResponse);
    }
```
- `IssueRepositoryImpl`에서 이슈 상세 DTO를 바로 조회하도록 함


---

## 지난번 PR
- 시간 관계상 모든걸 반영하지는 못 했습니다. ㅜㅜ
- 당장 디온이 말씀 주셨던 상세조회 부분을 다시 보니 매우 심각한 느낌이 들었습니다. 이 부분을 중점으로 했습니다.

---

## 다음에 할 것
- 마저 못 한 기능 구현
- OAuth/JWT
    - 우선순위 매우 높음. 이번에 학습하고 싶었는데 자꾸 미뤄서 아쉬웠어요. 좀 힘들고 시행착오가 있을 수 있겠지만 이번 김에 제대로 배워보고 싶습니다..)
- 예외처리
    - ExceptionHandler, Exception 메시지 공통화 처리
- 인터셉터 처리
  - 해당 요청에 대해 사용자가 접근 권한이 있는지 컨트롤러 접근 전에 판단하는 로직 (JWT, OAuth 선행 필요)
- 테스트 : 그동안 시간을 핑계로 테스트를 너무 미뤘습니다... 다음 주 수료식 일정 등등으로 인해 이 부분까지 할 수 있으리란 보장이 없긴 합니다. ㅜㅜ