### PR TITLE
[Team-05] [Lee] 이슈트래커 BE 2주차 2번째: 이슈 검색/필터 구현, 댓글 및 라벨 기능 구현, 예외 처리

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id 'java'
 }
 
@@ -21,6 +28,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -29,4 +38,26 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+// JPA 사용 여부와 사용할 경로를 설정
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+// build 시 사용할 sourceSet 추가
+sourceSets {
+	main.java.srcDir querydslDir
+}
+// querydsl 컴파일시 사용할 옵션 설정
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+// querydsl 이 compileClassPath 를 상속하도록 설정
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/QueryDslConfiguration.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/QueryDslConfiguration.java
@@ -1,0 +1,20 @@
+package kr.codesquad.issuetraker;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
@@ -53,4 +53,9 @@ public class IssueController {
     public ResponseEntity<NewCommentResponseDto> createComment(@PathVariable Long issueId, @RequestBody NewCommentRequestDto requestDto) {
         return ResponseEntity.ok(issueService.createComment(issueId, requestDto));
     }
+
+    @PatchMapping("/{issueId}/comments/{commentId}")
+    public ResponseEntity<GeneralResponseDto> modifyCommentContent(@PathVariable Long issueId, @PathVariable Long commentId, @RequestBody CommentModificationRequestDto requestDto) {
+        return ResponseEntity.ok(issueService.modifyComment(issueId, commentId, requestDto));
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
@@ -15,8 +15,8 @@ public class IssueController {
     private final IssueService issueService;
 
     @GetMapping
-    public ResponseEntity<List<IssueListResponseDto>> loadAllIssues() {
-        return ResponseEntity.ok(issueService.getAllIssues());
+    public ResponseEntity<List<IssueListResponseDto>> loadAllIssues(@ModelAttribute SearchFilterDto searchFilterDto) {
+        return ResponseEntity.ok(issueService.getAllIssues(searchFilterDto));
     }
 
     @PostMapping

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
@@ -58,4 +58,9 @@ public class IssueController {
     public ResponseEntity<GeneralResponseDto> modifyCommentContent(@PathVariable Long issueId, @PathVariable Long commentId, @RequestBody CommentModificationRequestDto requestDto) {
         return ResponseEntity.ok(issueService.modifyComment(issueId, commentId, requestDto));
     }
+
+    @DeleteMapping("/{issueId}/comments/{commentId}")
+    public ResponseEntity<GeneralResponseDto> deleteComment(@PathVariable Long issueId, @PathVariable Long commentId) {
+        return ResponseEntity.ok(issueService.deleteComment(issueId, commentId));
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/IssueController.java
@@ -48,4 +48,9 @@ public class IssueController {
     public ResponseEntity<List<CommentListResponseDto>> loadAllComments(@PathVariable Long issueId) {
         return ResponseEntity.ok(issueService.getAllComments(issueId));
     }
+
+    @PostMapping("/{issueId}/comments")
+    public ResponseEntity<NewCommentResponseDto> createComment(@PathVariable Long issueId, @RequestBody NewCommentRequestDto requestDto) {
+        return ResponseEntity.ok(issueService.createComment(issueId, requestDto));
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/LabelController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/LabelController.java
@@ -1,12 +1,12 @@
 package kr.codesquad.issuetraker.controller;
 
+import kr.codesquad.issuetraker.dto.LabelCreationRequestDto;
+import kr.codesquad.issuetraker.dto.LabelCreationResponseDto;
 import kr.codesquad.issuetraker.dto.LabelListResponseDto;
 import kr.codesquad.issuetraker.sevice.LabelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,5 +20,10 @@ public class LabelController {
     @GetMapping
     public ResponseEntity<List<LabelListResponseDto>> loadAllLabels() {
         return ResponseEntity.ok(labelService.getAllLabels());
+    }
+
+    @PostMapping
+    public ResponseEntity<LabelCreationResponseDto> createLabel(@RequestBody LabelCreationRequestDto requestDto) {
+        return ResponseEntity.ok(labelService.createLabel(requestDto));
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/LabelController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/LabelController.java
@@ -1,0 +1,24 @@
+package kr.codesquad.issuetraker.controller;
+
+import kr.codesquad.issuetraker.dto.LabelListResponseDto;
+import kr.codesquad.issuetraker.sevice.LabelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/labels")
+public class LabelController {
+
+    private final LabelService labelService;
+
+    @GetMapping
+    public ResponseEntity<List<LabelListResponseDto>> loadAllLabels() {
+        return ResponseEntity.ok(labelService.getAllLabels());
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
@@ -1,7 +1,6 @@
 package kr.codesquad.issuetraker.domain.issue;
 
 import kr.codesquad.issuetraker.domain.user.User;
-import kr.codesquad.issuetraker.dto.CommentModificationRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,6 +36,11 @@ public class Comment {
 
     public void modifyContent(String content) {
         this.content = content;
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    public void markAsDeleted() {
+        this.isDeleted = true;
         this.modifiedAt = LocalDateTime.now();
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
@@ -1,6 +1,7 @@
 package kr.codesquad.issuetraker.domain.issue;
 
 import kr.codesquad.issuetraker.domain.user.User;
+import kr.codesquad.issuetraker.dto.CommentModificationRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,6 +32,11 @@ public class Comment {
         this.author = author;
         this.content = content;
         this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    public void modifyContent(String content) {
+        this.content = content;
         this.modifiedAt = LocalDateTime.now();
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/Comment.java
@@ -25,4 +25,12 @@ public class Comment {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private boolean isDeleted;
+
+    public Comment(Issue issue, User author, String content) {
+        this.issue = issue;
+        this.author = author;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface IssueRepository extends JpaRepository<Issue, Long> {
+public interface IssueRepository extends JpaRepository<Issue, Long>, IssueRepositoryCustom {
     @Query(value = "SELECT i FROM Issue i where i.isDeleted = FALSE")
     public List<Issue> findAllAvailableIssues();
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryCustom.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryCustom.java
@@ -5,6 +5,6 @@ import kr.codesquad.issuetraker.dto.SearchFilterDto;
 import java.util.List;
 
 public interface IssueRepositoryCustom {
-    List<Issue> searchIssuesByFilter(SearchFilterDto searchFilterDto);
+    List<Issue> findIssuesByFilter(SearchFilterDto searchFilterDto);
 
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
@@ -20,11 +20,19 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
 
         return queryFactory.selectFrom(issue)
                 .where(issue.isDeleted.eq(false),
+                        likeTitle(searchFilterDto.getTitle()),
                         eqIsOpened(searchFilterDto.getIsOpened()),
                         eqAuthorId(searchFilterDto.getAuthorId()),
                         eqLabelId(searchFilterDto.getLabelId()),
                         eqMilestoneId(searchFilterDto.getMilestoneId()))
                 .fetch();
+    }
+
+    private BooleanExpression likeTitle(String title) {
+        if (Objects.isNull(title)) {
+            return null;
+        }
+        return issue.title.like("%" + title + "%");
     }
 
     private BooleanExpression eqIsOpened(Boolean isOpened) {

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
@@ -18,7 +18,8 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
     @Override
     public List<Issue> searchIssuesByFilter(SearchFilterDto searchFilterDto) {
         return queryFactory.selectFrom(issue)
-                .where(eqIsOpened(searchFilterDto.getIsOpened()),
+                .where(issue.isDeleted.eq(false),
+                        eqIsOpened(searchFilterDto.getIsOpened()),
                         eqAuthorId(searchFilterDto.getAuthorId()),
                         eqLabelId(searchFilterDto.getLabelId()),
                         eqMilestoneId(searchFilterDto.getMilestoneId()))

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
@@ -1,11 +1,14 @@
 package kr.codesquad.issuetraker.domain.issue;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.codesquad.issuetraker.dto.SearchFilterDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import static kr.codesquad.issuetraker.domain.issue.QIssue.issue;
 
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Repository
@@ -14,8 +17,39 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
 
     @Override
     public List<Issue> searchIssuesByFilter(SearchFilterDto searchFilterDto) {
-        QIssue
-
         return queryFactory.selectFrom(issue)
+                .where(eqIsOpened(searchFilterDto.getIsOpened()),
+                        eqAuthorId(searchFilterDto.getAuthorId()),
+                        eqLabelId(searchFilterDto.getLabelId()),
+                        eqMilestoneId(searchFilterDto.getMilestoneId()))
+                .fetch();
+    }
+
+    private BooleanExpression eqIsOpened(Boolean isOpened) {
+        if (Objects.isNull(isOpened)) {
+            return issue.isOpened.eq(true);
+        }
+        return issue.isOpened.eq(isOpened);
+    }
+
+    private BooleanExpression eqAuthorId(Long authorId) {
+        if (Objects.isNull(authorId)) {
+            return null;
+        }
+        return issue.author.id.eq(authorId);
+    }
+
+    private BooleanExpression eqLabelId(Long labelId) {
+        if (Objects.isNull(labelId)) {
+            return null;
+        }
+        return issue.label.id.eq(labelId);
+    }
+
+    private BooleanExpression eqMilestoneId(Long milestoneId) {
+        if (Objects.isNull(milestoneId)) {
+            return null;
+        }
+        return issue.milestone.id.eq(milestoneId);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepositoryImpl.java
@@ -16,7 +16,8 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Issue> searchIssuesByFilter(SearchFilterDto searchFilterDto) {
+    public List<Issue> findIssuesByFilter(SearchFilterDto searchFilterDto) {
+
         return queryFactory.selectFrom(issue)
                 .where(issue.isDeleted.eq(false),
                         eqIsOpened(searchFilterDto.getIsOpened()),

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/label/Label.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/label/Label.java
@@ -1,11 +1,15 @@
 package kr.codesquad.issuetraker.domain.label;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Getter
 @Entity
 public class Label {
@@ -15,5 +19,4 @@ public class Label {
     private String name;
     private String description;
     private String backgroundColor;
-    private String letterColor;
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/CommentModificationRequestDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/CommentModificationRequestDto.java
@@ -1,0 +1,11 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentModificationRequestDto {
+    private Long userId;
+    private String content;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/IssueDetailResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/IssueDetailResponseDto.java
@@ -35,6 +35,8 @@ public class IssueDetailResponseDto {
                .assignee(assignee)
                .title(issue.getTitle())
                .description(issue.getDescription())
+               .createdAt(issue.getCreatedAt())
+               .modifiedAt(issue.getModifiedAt())
                .isOpened(issue.isOpened())
                .build();
     }

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelCreationRequestDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelCreationRequestDto.java
@@ -1,0 +1,12 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LabelCreationRequestDto {
+    private String name;
+    private String description;
+    private String backgroundColor;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelCreationResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelCreationResponseDto.java
@@ -1,0 +1,10 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LabelCreationResponseDto {
+    private Long labelId;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelListResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/LabelListResponseDto.java
@@ -1,0 +1,24 @@
+package kr.codesquad.issuetraker.dto;
+
+import kr.codesquad.issuetraker.domain.label.Label;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LabelListResponseDto {
+    private Long labelId;
+    private String name;
+    private String description;
+    private String backgroundColor;
+
+    public static LabelListResponseDto of(Label label) {
+        return LabelListResponseDto.builder()
+                .labelId(label.getId())
+                .name(label.getName())
+                .description(label.getDescription())
+                .backgroundColor(label.getBackgroundColor())
+                .build();
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/NewCommentRequestDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/NewCommentRequestDto.java
@@ -1,0 +1,11 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewCommentRequestDto {
+    Long userId;
+    String content;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/NewCommentResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/NewCommentResponseDto.java
@@ -1,0 +1,10 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NewCommentResponseDto {
+    private Long commentId;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/SearchFilterDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/SearchFilterDto.java
@@ -1,12 +1,13 @@
 package kr.codesquad.issuetraker.dto;
 
+import javafx.beans.binding.BooleanExpression;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
 public class SearchFilterDto {
-    private boolean isOpened;
+    private Boolean isOpened;
     private Long authorId;
     private Long labelId;
     private Long milestoneId;

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/SearchFilterDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/SearchFilterDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class SearchFilterDto {
+    private String title;
     private Boolean isOpened;
     private Long authorId;
     private Long labelId;

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/CommentNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class CommentNotFoundException extends ResourceNotFoundException {
+    public CommentNotFoundException() {
+        super("요청하신 id에 해당하는 댓글 정보를 찾을 수 없습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/IssueNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/IssueNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class IssueNotFoundException extends ResourceNotFoundException {
+    public IssueNotFoundException() {
+        super("요청하신 id에 해당하는 이슈 정보를 찾을 수 없습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/LabelNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/LabelNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class LabelNotFoundException extends ResourceNotFoundException {
+    public LabelNotFoundException() {
+        super("요청하신 id에 해당하는 라벨 정보를 찾을 수 없습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/MilestoneNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/MilestoneNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class MilestoneNotFoundException extends ResourceNotFoundException {
+    public MilestoneNotFoundException() {
+        super("요청하신 id에 해당하는 마일스톤 정보를 찾을 수 없습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/ResourceNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.codesquad.issuetraker.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException() {
+
+    }
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/RuntimeExceptionHandler.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/RuntimeExceptionHandler.java
@@ -1,0 +1,20 @@
+package kr.codesquad.issuetraker.exception;
+
+import kr.codesquad.issuetraker.dto.GeneralResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class RuntimeExceptionHandler {
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<GeneralResponseDto> handleResourceNotFoundException(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new GeneralResponseDto(404, e.getMessage()));
+    }
+
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public ResponseEntity<GeneralResponseDto> handleIllegalArgumentException(Exception e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new GeneralResponseDto(400, "올바르지 않은 요청입니다."));
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/UserNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class UserNotFoundException extends ResourceNotFoundException {
+    public UserNotFoundException() {
+        super("요청하신 id에 해당하는 유저 정보를 찾을 수 없습니다");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -8,6 +8,7 @@ import kr.codesquad.issuetraker.domain.milestone.MilestoneRepository;
 import kr.codesquad.issuetraker.domain.user.User;
 import kr.codesquad.issuetraker.domain.user.UserRepository;
 import kr.codesquad.issuetraker.dto.*;
+import kr.codesquad.issuetraker.exception.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,10 +33,10 @@ public class IssueService {
     }
 
     public NewIssueResponseDto createIssue(NewIssueRequestDto requestDto) {
-        User author = userRepository.findById(requestDto.getAuthorId()).orElseThrow(() -> new RuntimeException());
-        User assignee = userRepository.findById(requestDto.getAssigneeId()).orElseThrow(() -> new RuntimeException());
-        Label label = labelRepository.findById(requestDto.getLabelId()).orElseThrow(() -> new RuntimeException());
-        Milestone milestone = milestoneRepository.findById(requestDto.getMileStoneId()).orElseThrow(() -> new RuntimeException());
+        User author = userRepository.findById(requestDto.getAuthorId()).orElseThrow(() -> new UserNotFoundException());
+        User assignee = userRepository.findById(requestDto.getAssigneeId()).orElseThrow(() -> new UserNotFoundException());
+        Label label = labelRepository.findById(requestDto.getLabelId()).orElseThrow(() -> new LabelNotFoundException());
+        Milestone milestone = milestoneRepository.findById(requestDto.getMileStoneId()).orElseThrow(() -> new LabelNotFoundException());
 
         Issue newIssue = Issue.builder()
                 .title(requestDto.getTitle())
@@ -54,17 +55,17 @@ public class IssueService {
     }
 
     public IssueDetailResponseDto getIssueDetail(Long issueId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new IssueNotFoundException());
         return IssueDetailResponseDto.of(issue);
     }
 
     public GeneralResponseDto modifyIssueContent(Long issueId, IssueModificationRequestDto requestDto) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new IssueNotFoundException());
 
-        Milestone milestone = milestoneRepository.findById(requestDto.getMileStoneId()).orElseThrow(() -> new RuntimeException());
-        Label label = labelRepository.findById(requestDto.getLabelId()).orElseThrow(() -> new RuntimeException());
-        User author = userRepository.findById(requestDto.getAuthorId()).orElseThrow(() -> new RuntimeException());
-        User assignee = userRepository.findById(requestDto.getAssigneeId()).orElseThrow(() -> new RuntimeException());
+        Milestone milestone = milestoneRepository.findById(requestDto.getMileStoneId()).orElseThrow(() -> new MilestoneNotFoundException());
+        Label label = labelRepository.findById(requestDto.getLabelId()).orElseThrow(() -> new LabelNotFoundException());
+        User author = userRepository.findById(requestDto.getAuthorId()).orElseThrow(() -> new UserNotFoundException());
+        User assignee = userRepository.findById(requestDto.getAssigneeId()).orElseThrow(() -> new UserNotFoundException());
 
         IssueModificationFields modificationFieldsDto = IssueModificationFields.builder()
                 .title(requestDto.getTitle())
@@ -81,14 +82,14 @@ public class IssueService {
     }
 
     public GeneralResponseDto changeIssueStatus(Long issueId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new IssueNotFoundException());
         issue.toggleIsOpened();
         issueRepository.save(issue);
         return new GeneralResponseDto(200, "이슈 상태가 변경되었습니다.");
     }
 
     public GeneralResponseDto deleteIssue(Long issueId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new IssueNotFoundException());
         issue.markAsDeleted();
         issueRepository.save(issue);
         return new GeneralResponseDto(200, "이슈가 삭제되었습니다.");
@@ -102,8 +103,8 @@ public class IssueService {
     }
 
     public NewCommentResponseDto createComment(Long issueId, NewCommentRequestDto requestDto) {
-        User author = userRepository.findById(requestDto.getUserId()).orElseThrow(() -> new RuntimeException());
-        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+        User author = userRepository.findById(requestDto.getUserId()).orElseThrow(() -> new UserNotFoundException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new IssueNotFoundException());
 
         Comment comment = new Comment(issue, author, requestDto.getContent());
         Comment savedComment = commentRepository.save(comment);
@@ -111,14 +112,14 @@ public class IssueService {
     }
 
     public GeneralResponseDto modifyComment(Long issueId, Long commentId, CommentModificationRequestDto requestDto) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException());
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentNotFoundException());
         comment.modifyContent(requestDto.getContent());
         commentRepository.save(comment);
         return new GeneralResponseDto(200, "댓글이 수정되었습니다.");
     }
 
     public GeneralResponseDto deleteComment(Long issueId, Long commentId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException());
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentNotFoundException());
         comment.markAsDeleted();
         commentRepository.save(comment);
         return new GeneralResponseDto(200, "댓글이 삭제되었습니다.");

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -25,7 +25,7 @@ public class IssueService {
     private final LabelRepository labelRepository;
 
     public List<IssueListResponseDto> getAllIssues(SearchFilterDto searchFilterDto) {
-        List<Issue> issues = issueRepository.findAllAvailableIssues(searchFilterDto);
+        List<Issue> issues = issueRepository.findIssuesByFilter(searchFilterDto);
         return issues.stream()
                 .map(IssueListResponseDto::of)
                 .collect(Collectors.toList());
@@ -46,6 +46,7 @@ public class IssueService {
                 .label(label)
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
+                .isOpened(true)
                 .build();
 
         Issue savedIssue = issueRepository.save(newIssue);

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -24,8 +24,8 @@ public class IssueService {
     private final MilestoneRepository milestoneRepository;
     private final LabelRepository labelRepository;
 
-    public List<IssueListResponseDto> getAllIssues() {
-        List<Issue> issues = issueRepository.findAllAvailableIssues();
+    public List<IssueListResponseDto> getAllIssues(SearchFilterDto searchFilterDto) {
+        List<Issue> issues = issueRepository.findAllAvailableIssues(searchFilterDto);
         return issues.stream()
                 .map(IssueListResponseDto::of)
                 .collect(Collectors.toList());

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -116,4 +116,11 @@ public class IssueService {
         commentRepository.save(comment);
         return new GeneralResponseDto(200, "댓글이 수정되었습니다.");
     }
+
+    public GeneralResponseDto deleteComment(Long issueId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException());
+        comment.markAsDeleted();
+        commentRepository.save(comment);
+        return new GeneralResponseDto(200, "댓글이 삭제되었습니다.");
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -100,4 +100,13 @@ public class IssueService {
                 .map(CommentListResponseDto::of)
                 .collect(Collectors.toList());
     }
+
+    public NewCommentResponseDto createComment(Long issueId, NewCommentRequestDto requestDto) {
+        User author = userRepository.findById(requestDto.getUserId()).orElseThrow(() -> new RuntimeException());
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new RuntimeException());
+
+        Comment comment = new Comment(issue, author, requestDto.getContent());
+        Comment savedComment = commentRepository.save(comment);
+        return new NewCommentResponseDto(savedComment.getId());
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/IssueService.java
@@ -109,4 +109,11 @@ public class IssueService {
         Comment savedComment = commentRepository.save(comment);
         return new NewCommentResponseDto(savedComment.getId());
     }
+
+    public GeneralResponseDto modifyComment(Long issueId, Long commentId, CommentModificationRequestDto requestDto) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException());
+        comment.modifyContent(requestDto.getContent());
+        commentRepository.save(comment);
+        return new GeneralResponseDto(200, "댓글이 수정되었습니다.");
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/LabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/LabelService.java
@@ -2,6 +2,8 @@ package kr.codesquad.issuetraker.sevice;
 
 import kr.codesquad.issuetraker.domain.label.Label;
 import kr.codesquad.issuetraker.domain.label.LabelRepository;
+import kr.codesquad.issuetraker.dto.LabelCreationRequestDto;
+import kr.codesquad.issuetraker.dto.LabelCreationResponseDto;
 import kr.codesquad.issuetraker.dto.LabelListResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,5 +22,15 @@ public class LabelService {
         return labels.stream()
                 .map(LabelListResponseDto::of)
                 .collect(Collectors.toList());
+    }
+
+    public LabelCreationResponseDto createLabel(LabelCreationRequestDto requestDto) {
+        Label label = Label.builder()
+                .name(requestDto.getName())
+                .description(requestDto.getDescription())
+                .backgroundColor(requestDto.getBackgroundColor())
+                .build();
+        Label savedLabel = labelRepository.save(label);
+        return new LabelCreationResponseDto(savedLabel.getId());
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/LabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/LabelService.java
@@ -1,0 +1,24 @@
+package kr.codesquad.issuetraker.sevice;
+
+import kr.codesquad.issuetraker.domain.label.Label;
+import kr.codesquad.issuetraker.domain.label.LabelRepository;
+import kr.codesquad.issuetraker.dto.LabelListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class LabelService {
+
+    private final LabelRepository labelRepository;
+
+    public List<LabelListResponseDto> getAllLabels() {
+        List<Label> labels = labelRepository.findAll();
+        return labels.stream()
+                .map(LabelListResponseDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -8,7 +8,11 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
 logging:
   level:
     org.hibernate.sql: debug
+    org.hibernate.type.descriptor.sql: trace
 

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -1,3 +1,3 @@
 insert into user (display_name, email, password, profile_image_url) values ('lee', 'lee@lee.com', 'pwpw', 'image.jpg');
-insert into label (name, background_color, letter_color, description) values ('feature', '0xFFFFFF', '0x000000', 'test label');
+insert into label (name, background_color, description) values ('feature', '0xFFFFFF', 'test label');
 insert into milestone (title, is_deleted) values ('test milestone', false);


### PR DESCRIPTION
안녕하세요 로치!
5팀 백엔드 Lee입니다. 금요일 PR은 조금만 마무리해야지 하다가 마감보다 좀 늦어지네요. 죄송합니다 흑흑.

# 작업 내용
### QueryDsl을 활용한 이슈 검색 및 필터 기능 구현
- QueryDsl의 `BooleanExpression` 기능을 사용해서 이슈 검색과 필터 기능을 구현했습니다.
- 기본적으로 `isDeleted`는 false 조건이고, `isOpened` 조건이 안 들어올 때는 기본값을 열려 있는 이슈로 잡아서 작업했습니다.

### 이슈 댓글 관련 기능, 라벨 관련 기능 구현
- 이전 도메인과 비슷한 형태로 구현했습니다.

### Exception 세분화 및 메시지 처리
 - `ResourceNotFoundException` 클래스를 정의하고, 각 엔티티별로 해당 예외를 상속하는 예외을 정의해 메시지를 설정했습니다.
 - 이후` @ControllerAdvice`를 통해 `ResourceNotFoundException`은 NOT FOUND(404)로 던지면서 메시지를 바디로 넣었습니다.
 - service 단에서 findbyId로 가져올 때 클라이언트에서 넘어온 파라미터가 null일 경우 `IllegalArgumentException`이 터지는데, 이건 BAD REQUEST(400)으로 던지는 것으로 잡았습니다. 우선 이렇게 처리하긴 했는데 해당 예외가 이 경우에만 뜨는 건 아닐 거 같아서, 추후에 조금 더 세분화된 예외처리 케이스를 지정해줘야 할 것 같습니다!

# 질문사항
- 지난 PR에서 삭제 처리 시 `Listener`를 사용하는 게 어떻냐는 피드백 주셔서 자료를 좀 찾아보았는데, 제가 해당 개념을 제대로 몰라서 그런지 이해가 제대로 안 된 것 같습니다. 혹시 참고할 자료나, 그냥 요청과 비교했을 때 장점이 무엇인지 조금만 더 설명해주실 수 있을까요?


지난 리뷰에서 말씀해주신 대로 테스트 코드와 로깅 관련한 내용도 추가해야 하는데, 혼자 진행하다 보니 시간이 오래 걸려서 우선은 구현 위주로 진행하게 되네요. 계속 염두에 두고 진행사항 봐 가면서 차근차근 진행해 보겠습니다.

그럼 이번에도 잘 부탁드립니다. 늘 좋은 리뷰 감사합니다!-!