### PR TITLE
[Team-30][FE] Cola, Muffin 3주차 1번째 PR

### DIFF
--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -33,6 +33,9 @@ module.exports = {
     'react/function-component-definition': 'off',
     'jsx-a11y/label-has-associated-control': 'off',
     'no-use-before-define': 'off',
+    'jsx-a11y/control-has-associated-label': 'off',
+    'react-hooks/rules-of-hooks': 'off',
+
     'import/order': [
       'error',
       {

--- a/FE/public/index.html
+++ b/FE/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/FE/src/Router.tsx
+++ b/FE/src/Router.tsx
@@ -6,6 +6,7 @@ import ButtonPage from '@pages/ButtonPage';
 import Callback from '@pages/Callback';
 import IconPage from '@pages/IconPage';
 import IssuePage from '@pages/IssuePage';
+import IssueDetailPage from '@pages/IssuePage/Detail';
 import LabelPage from '@pages/LabelPage';
 import Login from '@pages/Login';
 import Milestone from '@pages/Milestone';
@@ -21,6 +22,9 @@ export default function Router() {
         <Route element={<Verification />}>
           <Route path="/issue" element={<Layout />}>
             <Route index element={<IssuePage />} />
+            <Route path="new" element={<IssueDetailPage newIssue />} />
+            <Route path=":id" element={<IssueDetailPage />} />
+            {/**/}
             <Route path="label" element={<LabelPage />} />
             <Route path="milestone" element={<Milestone />} />
           </Route>

--- a/FE/src/apis/issue.ts
+++ b/FE/src/apis/issue.ts
@@ -1,0 +1,33 @@
+import { ACCESS_TOKEN } from '@constants/cookie';
+import { getCookie } from '@utils/cookie';
+
+interface PostIssueRequestBody {
+  title: 'string';
+  content: 'string'; // Comment
+  assigneesId: number[];
+  labelsId: number[];
+  milestoneId: number;
+}
+
+export const postIssue = async (
+  requestBody: PostIssueRequestBody,
+): Promise<{ issueId: number }> => {
+  const accessToken = getCookie(ACCESS_TOKEN);
+  const response = await fetch(`${process.env.TEAM30_BASE_URL}/api/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  const data = await response.json();
+
+  // TODO: 임시 로직 고치기
+  if (!Object.hasOwn(data, 'issueId')) {
+    throw Error('이슈 등록 실패');
+  }
+
+  return data;
+};

--- a/FE/src/apis/label.ts
+++ b/FE/src/apis/label.ts
@@ -1,0 +1,10 @@
+import { Label } from '@type/label';
+
+export const getLabels = async (): Promise<Label[]> => {
+  const response = await fetch(`${process.env.TEAM30_BASE_URL}/api/labels`);
+  const data = await response.json();
+
+  // TODO: 에러핸들링
+
+  return data;
+};

--- a/FE/src/apis/milestone.ts
+++ b/FE/src/apis/milestone.ts
@@ -1,0 +1,10 @@
+import { MileStone } from '@type/milestone';
+
+export const getMileStones = async (): Promise<MileStone[]> => {
+  const response = await fetch(`${process.env.TEAM30_BASE_URL}/api/milestones`);
+  const data = await response.json();
+
+  // TODO: 에러핸들링
+
+  return data;
+};

--- a/FE/src/apis/user.ts
+++ b/FE/src/apis/user.ts
@@ -1,0 +1,10 @@
+import { User } from '@type/user';
+
+export const getUsers = async (): Promise<User[]> => {
+  const response = await fetch(`${process.env.TEAM30_BASE_URL}/users`);
+  const data = await response.json();
+
+  // TODO: 에러핸들링
+
+  return data;
+};

--- a/FE/src/components/Button/index.tsx
+++ b/FE/src/components/Button/index.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import * as S from './style';
 
+import { Loader } from '@components/Indicator';
 import { OverridableProps } from '@utils/types';
 
 type ButtonProps<T extends React.ElementType> = OverridableProps<
@@ -30,25 +31,31 @@ type LoginButtonProps<T extends React.ElementType> = OverridableProps<
   }
 >;
 
-export const Button = <T extends React.ElementType = 'button'>({
+const TButton = <T extends React.ElementType = 'button'>({
   children,
   outlined = false,
   size = 'sm',
+  loading,
   as,
   ...restProps
-}: ButtonProps<T>) => (
-  <S.Button
-    as={as ?? 'button'}
-    type="button"
-    outlined={outlined}
-    size={size}
-    {...restProps}
-  >
-    <span>{children}</span>
-  </S.Button>
-);
+}: ButtonProps<T>) =>
+  loading ? (
+    <S.LoaderWrapper size={size}>
+      <Loader size={3} />
+    </S.LoaderWrapper>
+  ) : (
+    <S.Button
+      as={as ?? 'button'}
+      type="button"
+      outlined={outlined}
+      size={size}
+      {...restProps}
+    >
+      <span>{children}</span>
+    </S.Button>
+  );
 
-export const TextButton = <T extends React.ElementType = 'button'>({
+const TTextButton = <T extends React.ElementType = 'button'>({
   children,
   size = 'sm',
   as,
@@ -75,3 +82,6 @@ export const LoginButton = <T extends React.ElementType = 'button'>({
     {children}
   </S.LoginButton>
 );
+
+export const Button = memo(TButton);
+export const TextButton = memo(TTextButton);

--- a/FE/src/components/Button/style.ts
+++ b/FE/src/components/Button/style.ts
@@ -6,12 +6,24 @@ import {
   typoMedium,
   typoSmall,
   simpleOpacityTransition,
+  flexbox,
 } from '@styles/mixin';
 
 // 버튼
 // 색상에 따라 Normal, Outlined
 // 크기에 따라 Large, Medium, Small
 // 종류에 따라 Button, TextButton
+const WIDTH = {
+  LG: 21.25,
+  MD: 15,
+  SM: 7.5,
+};
+
+const HEIGHT = {
+  LG: 4,
+  MD: 3.5,
+  SM: 2.5,
+};
 
 export const Button = styled.button<{
   outlined?: boolean;
@@ -23,9 +35,10 @@ export const Button = styled.button<{
   cursor: pointer;
 
   min-width: ${({ size }) =>
-    size === 'lg' ? 21.25 : size === 'md' ? 15 : 7.5}rem;
+    size === 'lg' ? WIDTH.LG : size === 'md' ? WIDTH.MD : WIDTH.SM}rem;
 
-  height: ${({ size }) => (size === 'lg' ? 4 : size === 'md' ? 3.5 : 2.5)}rem;
+  height: ${({ size }) =>
+    size === 'lg' ? HEIGHT.LG : size === 'md' ? HEIGHT.MD : HEIGHT.SM}rem;
   border-radius: ${({ size }) => (size === 'lg' || size === 'md' ? 20 : 11)}px;
 
   background-color: ${({ theme, outlined }) =>
@@ -67,6 +80,7 @@ export const Button = styled.button<{
 `;
 
 export const TextButton = styled.button<{ size: 'sm' | 'md' }>`
+  ${flexbox({ jc: 'center', ai: 'center' })}
   background-color: inherit;
   color: ${({ theme }) => theme.color.label};
   cursor: pointer;
@@ -117,4 +131,12 @@ export const LoginButton = styled.button<{
     cursor: not-allowed;
     pointer-events: none;
   }
+`;
+
+export const LoaderWrapper = styled.div<{ size?: 'sm' | 'md' | 'lg' }>`
+  ${flexbox({ jc: 'center', ai: 'center' })}
+  min-width: ${({ size }) =>
+    size === 'lg' ? WIDTH.LG : size === 'md' ? WIDTH.MD : WIDTH.SM}rem;
+  height: ${({ size }) =>
+    size === 'lg' ? HEIGHT.LG : size === 'md' ? HEIGHT.MD : HEIGHT.SM}rem;
 `;

--- a/FE/src/components/FilterBar/index.tsx
+++ b/FE/src/components/FilterBar/index.tsx
@@ -18,11 +18,11 @@ import { useSearch } from '@hooks/useSearch';
 export default function FilterBar() {
   const issueFilterData = {
     info: [
-      { id: 1, status: 'is:open', name: '열린이슈' },
-      { id: 2, status: 'mine:me', name: '내가작성한이슈' },
-      { id: 3, status: 'assignedToMe:me', name: '나에게할당된이슈' },
-      { id: 4, status: 'comment:me', name: '내가댓글을남긴이슈' },
-      { id: 5, status: 'is:close', name: '닫힌이슈' },
+      { status: 'is:open', name: '열린이슈' },
+      { status: 'mine:me', name: '내가작성한이슈' },
+      { status: 'assignedToMe:me', name: '나에게할당된이슈' },
+      { status: 'comment:me', name: '내가댓글을남긴이슈' },
+      { status: 'is:close', name: '닫힌이슈' },
     ],
   };
 
@@ -44,7 +44,7 @@ export default function FilterBar() {
     popupData: IPopupData,
   ) => {
     e.stopPropagation();
-    init({ paramValue: popupData.status });
+    init({ paramValue: popupData.status! });
     setIsComponentVisible(false);
   };
 
@@ -83,7 +83,7 @@ export default function FilterBar() {
               <header>이슈 필터</header>
               {issueFilterData.info.map((popupData: IPopupData) => (
                 <Contents
-                  key={`popup-${popupData.id}`}
+                  key={`popup-${popupData.name}`}
                   label="이슈"
                   popupData={popupData}
                   handleItemClick={handleItemClick}

--- a/FE/src/components/FilterBar/style.ts
+++ b/FE/src/components/FilterBar/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { typoSmall, flexbox } from '@styles/mixin';
+import { typoXSmall, typoSmall, flexbox } from '@styles/mixin';
 
 export const Icon = styled.span`
   position: absolute;
@@ -57,7 +57,17 @@ export const FilterButton = styled.div`
   }
 `;
 
+export const FilterErrorText = styled.div`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: -11rem;
+  color: ${({ theme }) => theme.color.red};
+  ${typoXSmall(400)}
+`;
+
 export const FilterBarLayer = styled.form`
+  position: relative;
   display: inline-flex;
   height: 2.5rem;
   border: 1px solid ${({ theme }) => theme.color.line};

--- a/FE/src/components/Indicator/Loader/index.tsx
+++ b/FE/src/components/Indicator/Loader/index.tsx
@@ -3,25 +3,32 @@ import React from 'react';
 
 import * as S from './style';
 
-import { alignPosXY, flexbox } from '@styles/mixin';
+import { alignPosXY } from '@styles/mixin';
 import theme from '@styles/theme';
 
-export const Loader: React.FC<{ text?: string; size?: number }> = ({
+export const Loader: React.FC<{
+  text?: string;
+  size?: number;
+  loaderColor?: string;
+  textColor?: string;
+}> = ({
   text,
   size = 1,
+  loaderColor = theme.color.titleActive,
+  textColor = theme.color.titleActive,
 }) => (
   <div
     css={css`
+      display: inline-block;
       position: relative;
     `}
   >
     <div
       css={css`
-        ${alignPosXY('fixed')};
-        ${flexbox({ jc: 'center', ai: 'center' })}
+        ${alignPosXY()};
         width: ${size}rem;
         height: ${size}rem;
-        border: 0.5rem solid ${theme.color.titleActive};
+        border: 0.5rem solid ${loaderColor};
         border-top-color: transparent;
         border-bottom-color: transparent;
         border-radius: 50%;
@@ -31,10 +38,11 @@ export const Loader: React.FC<{ text?: string; size?: number }> = ({
     {text && (
       <div
         css={css`
-          ${alignPosXY('fixed')};
+          ${alignPosXY()};
+          white-space: nowrap;
           font-size: 1.3rem;
           animation: ${S.shakeAnimation} 100ms infinite;
-          color: ${theme.color.titleActive};
+          color: ${textColor};
         `}
       >
         {text}

--- a/FE/src/components/Input/index.tsx
+++ b/FE/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React, { memo, useId } from 'react';
 
 import * as S from './style';
 
@@ -27,7 +27,7 @@ type TextareaProps<T extends React.ElementType> = OverridableProps<
   }
 >;
 
-export const Input = <T extends React.ElementType = 'input'>({
+export const TInput = <T extends React.ElementType = 'input'>({
   width,
   placeholder,
   size = 'sm',
@@ -50,7 +50,7 @@ export const Input = <T extends React.ElementType = 'input'>({
   </S.InputLayer>
 );
 
-export const Textarea = <T extends React.ElementType = 'input'>({
+export const TTextarea = <T extends React.ElementType = 'input'>({
   width,
   placeholder,
   value = '',
@@ -82,3 +82,6 @@ export const Textarea = <T extends React.ElementType = 'input'>({
     </S.TextareaLayer>
   );
 };
+
+export const Textarea = memo(TTextarea);
+export const Input = memo(TInput);

--- a/FE/src/components/Issue/Filter/index.tsx
+++ b/FE/src/components/Issue/Filter/index.tsx
@@ -11,44 +11,45 @@ import { useSearch } from '@hooks/useSearch';
 
 interface IFilterProps {
   onPopup: boolean;
-  label: FilterLabelTypes;
+  item: FilterLabelTypes;
   filterPopupData: IPopupData[];
-  handleFilterClick: (label: FilterLabelTypes, status: boolean) => void;
+  handleFilterClick: (item: FilterLabelTypes, status: boolean) => void;
 }
 
 export default function Filter({
   onPopup,
-  label,
+  item,
   filterPopupData,
   handleFilterClick,
 }: IFilterProps) {
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
   const handleOnFilterPopup = () => {
-    handleFilterClick(label, true);
+    handleFilterClick(item, true);
     setIsComponentVisible(!isComponentVisible);
   };
-  const { replace } = useSearch('q', '');
+  const { replace } = useSearch('q', 'is:open');
 
   const handleItemClick = (
     e: React.MouseEvent<HTMLElement>,
     popupData: IPopupData,
   ) => {
     e.stopPropagation();
-    replace(label, popupData.name);
+    if (item === 'label') replace(item, popupData.title);
+    else replace(item, popupData.name);
     setIsComponentVisible(false);
   };
 
   return (
     <S.FilterLayer onClick={handleOnFilterPopup}>
-      <span className="filter__label">{label}</span>
+      <span className="filter__label">{item}</span>
       <S.ArrowDown />
       {/**
        * // TODO
        * 초기에 여러개의 필터 팝업창 중에 하나의 필터 팝업창만 어떻게 띄울까 고민함
        * 팝업마다 보여줘야할 데이터가 다르기 때문에 팝업의 상태를 객체로 관리하는게 맞을꺼같아 우선 진행
-       * 현재 모든 팝업의 상태를 불린형태로 popupState[label]로 관리
-       * popupState[label]이 true인 팝업만 초기에 띄워주지만
+       * 현재 모든 팝업의 상태를 불린형태로 popupState[item]로 관리
+       * popupState[item]이 true인 팝업만 초기에 띄워주지만
        * 모든 팝업을 한 번씩 클릭하면 결국 전부 true가 되서 초기에만 사용되는 변수값으로 전락되버림
        *
        *
@@ -67,11 +68,11 @@ export default function Filter({
         >
           {isComponentVisible && (
             <Popup>
-              <header>{label} 필터</header>
+              <header>{item} 필터</header>
               {filterPopupData.map((popupData: IPopupData) => (
                 <Contents
                   key={`popup-${popupData.id}`}
-                  label={label}
+                  item={item}
                   popupData={popupData}
                   handleItemClick={handleItemClick}
                 />

--- a/FE/src/components/Issue/Item/index.tsx
+++ b/FE/src/components/Issue/Item/index.tsx
@@ -17,16 +17,30 @@ interface IIssueItem {
   title: string;
 }
 
+interface IssueItemProps {
+  issue: IIssueItem;
+  lastIdx?: boolean;
+  isCheck: boolean;
+  handleIssueCheck: (id: number) => void;
+}
+
 export default function Item({
   issue,
   lastIdx,
-}: {
-  issue: IIssueItem;
-  lastIdx?: boolean;
-}) {
+  isCheck,
+  handleIssueCheck,
+}: IssueItemProps) {
   return (
     <ItemLayer lastIdx={lastIdx}>
-      <I.CheckBox.Initial color="#D9DBE9" />
+      {isCheck ? (
+        <button type="button" onClick={() => handleIssueCheck(issue.id)}>
+          <I.CheckBox.Active color="#007AFF" />
+        </button>
+      ) : (
+        <button type="button" onClick={() => handleIssueCheck(issue.id)}>
+          <I.CheckBox.Initial color="#D9DBE9" />
+        </button>
+      )}
       <ContentLayer>
         <div>
           <I.Circle.Alert color="#007AFF" />

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -103,12 +103,12 @@ export default function Navigation() {
         </S.IssueLabel>
       </S.LeftLayer>
       <S.RightLayer>
-        {filterLabels.map((label: FilterLabelTypes) => (
+        {filterLabels.map((item: FilterLabelTypes) => (
           <Filter
-            key={label}
-            onPopup={onPopup(label)}
-            label={label}
-            filterPopupData={filterPopupData[label].info}
+            key={item}
+            onPopup={onPopup(item)}
+            item={item}
+            filterPopupData={filterPopupData[item].info}
             handleFilterClick={handleFilterClick}
           />
         ))}

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useRecoilValue, useRecoilState } from 'recoil';
 
-import { NavigationLayer, LeftLayer, RightLayer, IssueLabel } from './style';
+import * as S from './style';
 
 import I from '@components/Icons';
 import Filter from '@components/Issue/Filter';
@@ -46,10 +46,7 @@ export default function Navigation() {
     author: authorData,
   });
 
-  const [labelIssueStatus, setLabelIssueStatus] = useState({
-    open: true,
-    close: false,
-  });
+  const [labelIssueStatus, setLabelIssueStatus] = useState(true);
 
   const openIssueCount = issues.filter(issue => issue.status === 'open').length;
   const closeIssueCount = issues.filter(
@@ -58,10 +55,10 @@ export default function Navigation() {
 
   const handleLabelClick = (status: string) => {
     if (status === 'open') {
-      setLabelIssueStatus({ open: true, close: false });
+      setLabelIssueStatus(true);
       init({ paramValue: 'is:open' });
     } else if (status === 'close') {
-      setLabelIssueStatus({ open: false, close: true });
+      setLabelIssueStatus(false);
       init({ paramValue: 'is:close' });
     }
   };
@@ -73,40 +70,39 @@ export default function Navigation() {
   const onPopup = (label: FilterLabelTypes) => !!popupState[label];
 
   useEffect(() => {
-    const urlSearch = decodeURI(decodeURIComponent(location.search));
-    const params = new URLSearchParams(urlSearch);
+    const params = new URLSearchParams(location.search);
     const urlValues = params.get('q');
 
     if (urlValues === null) return;
 
     if (urlValues === 'is:open') {
-      setLabelIssueStatus({ open: true, close: false });
+      setLabelIssueStatus(true);
     } else if (urlValues === 'is:close') {
-      setLabelIssueStatus({ open: false, close: true });
+      setLabelIssueStatus(false);
     }
   }, [location]);
 
   return (
-    <NavigationLayer>
-      <LeftLayer>
+    <S.NavigationLayer>
+      <S.LeftLayer>
         <I.CheckBox.Initial color="#D9DBE9" />
-        <IssueLabel
-          labelIssueStatus={labelIssueStatus.open}
+        <S.IssueLabel
+          labelIssueStatus={labelIssueStatus}
           onClick={() => handleLabelClick('open')}
         >
           <I.Circle.Alert />
           <span>열린 이슈({openIssueCount})</span>
-        </IssueLabel>
+        </S.IssueLabel>
 
-        <IssueLabel
-          labelIssueStatus={labelIssueStatus.close}
+        <S.IssueLabel
+          labelIssueStatus={!labelIssueStatus}
           onClick={() => handleLabelClick('close')}
         >
           <I.Bucket />
           <span>닫힌 이슈({closeIssueCount})</span>
-        </IssueLabel>
-      </LeftLayer>
-      <RightLayer>
+        </S.IssueLabel>
+      </S.LeftLayer>
+      <S.RightLayer>
         {filterLabels.map((label: FilterLabelTypes) => (
           <Filter
             key={label}
@@ -116,7 +112,7 @@ export default function Navigation() {
             handleFilterClick={handleFilterClick}
           />
         ))}
-      </RightLayer>
-    </NavigationLayer>
+      </S.RightLayer>
+    </S.NavigationLayer>
   );
 }

--- a/FE/src/components/Issue/index.tsx
+++ b/FE/src/components/Issue/index.tsx
@@ -18,20 +18,16 @@ export default function Issue() {
   const [renderIssue, setRenderIssue] = useState<IIssueTypes[]>([]);
   const location = useLocation();
 
-  useQuery('issueData', () => {
-    fetch('issue').then(res => {
-      res.json().then(result => {
-        setInitIssue(result);
-        setRenderIssue(
-          result.filter((issue: IIssueTypes) => issue.status === 'open'),
-        );
-      });
-    });
+  useQuery('issueData', async () => {
+    const response = await (await fetch('issue')).json();
+    setInitIssue(response);
+    setRenderIssue(
+      response.filter((issue: IIssueTypes) => issue.status === 'open'),
+    );
   });
 
   useEffect(() => {
-    const urlSearch = decodeURI(decodeURIComponent(location.search));
-    const params = new URLSearchParams(urlSearch);
+    const params = new URLSearchParams(location.search);
     const urlValues = params.get('q');
 
     if (urlValues === null) return;

--- a/FE/src/components/Label/Form.tsx
+++ b/FE/src/components/Label/Form.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { css } from '@emotion/react';
+import { useState, useEffect } from 'react';
+import { useMutation } from 'react-query';
 
 import * as S from './formStyle';
 
@@ -6,36 +8,141 @@ import { Button } from '@components/Button';
 import I from '@components/Icons';
 import { Input } from '@components/Input';
 import { Label } from '@components/Label';
+import Popup from '@components/Popup';
 import RadioSelection from '@components/RadioSelection';
+import {
+  radioColorText,
+  initBgColor,
+  defaultBgColors,
+} from '@constants/default';
+import useComponentVisible from '@hooks/useComponentVisible';
+import { ILabelTypes } from '@recoil/atoms/label';
+import { typoXSmall, flexbox } from '@styles/mixin';
+import theme from '@styles/theme';
 
-export default function Form({ title }: { title: string }) {
-  const [labelText, setLabelText] = useState('');
-  const [descriptionText, setDescriptionText] = useState('');
-  const [bgColor, setBgColor] = useState('#EFF0F6');
-  const [colorText, setColorText] = useState({
-    darkColor: true,
-    whiteColor: false,
+interface FormProps {
+  title: string;
+  labelData?: ILabelTypes;
+  onEdit: boolean;
+  handleCloseForm: (id?: number) => void;
+}
+
+export default function Form({
+  title,
+  labelData,
+  onEdit,
+  handleCloseForm,
+}: FormProps) {
+  const { ref, isComponentVisible, setIsComponentVisible } =
+    useComponentVisible(false);
+
+  const [openFormValue, setOpenFormValue] = useState({
+    labelText: labelData?.title || '',
+    descriptionText: labelData?.description || '',
+    bgColor: labelData?.backgroundColor || initBgColor,
+    radioState:
+      labelData?.textColor === 'BLACK'
+        ? '어두운색'
+        : '밝은색' || radioColorText[0],
   });
-  const [complelteBtn, setComplelteBtn] = useState(false);
+
+  const [initFormValue, setInitFormValue] = useState({
+    labelText: openFormValue.labelText,
+    descriptionText: openFormValue.descriptionText,
+    bgColor: openFormValue.bgColor,
+    radioState: openFormValue.radioState,
+  });
 
   const handleLabelText = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLabelText(e.target.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      labelText: e.target.value,
+    }));
   };
 
   const handleDescriptionText = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDescriptionText(e.target.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      descriptionText: e.target.value,
+    }));
   };
 
-  const handleBgColor = (e: React.MouseEvent<HTMLElement>) => {
-    setBgColor('#000000');
+  const handleBgColor = () => {
+    // 랜덤 컬러 색상 만드는 함수
+    const randomColor = new Array(3).fill(0).reduce((prev: string) => {
+      // eslint-disable-next-line no-param-reassign
+      prev += Math.floor(Math.random() * 127 + 128)
+        .toString(16)
+        .toUpperCase();
+      return prev;
+    }, '#');
+
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: randomColor,
+    }));
   };
 
-  const handleColorText = (e: any) => {
-    console.log(e.target);
+  const handleColorText = (color: string) => {
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      radioState: color,
+    }));
   };
+
+  const onColorPopup = () => {
+    setIsComponentVisible(true);
+  };
+
+  const onChangeColor = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value === '') e.target.value = '#';
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: e.target.value,
+    }));
+  };
+
+  const handleColorClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    e.stopPropagation();
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: button.value,
+    }));
+    setIsComponentVisible(false);
+  };
+
+  const createLabelPost = useMutation((newLabel: ILabelTypes) =>
+    fetch('/issue/label', {
+      method: 'POST',
+      body: JSON.stringify(newLabel),
+    }),
+  );
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const newLabel = {
+      id: 3,
+      title: openFormValue.labelText,
+      description: openFormValue.descriptionText,
+      backgroundColor: openFormValue.bgColor,
+      textColor: openFormValue.radioState === '어두운색' ? 'BLACK' : 'WHITE',
+    };
+
+    createLabelPost.mutate(newLabel);
+  };
+
+  useEffect(() => {
+    // 임시로 응답이 정상적으로 왔을때 처리 차후는 Persist mutation 적용필요
+    if (createLabelPost.isSuccess) {
+      alert('label add success');
+      handleCloseForm();
+    }
+  }, [createLabelPost, handleCloseForm]);
 
   return (
-    <S.FormWrapper title={title}>
+    <S.FormWrapper title={title} onSubmit={handleSubmit}>
       <S.FormLeftInner>
         <S.FormTitle>{title}</S.FormTitle>
         <Label bgColor="#EFF0F6" darkText>
@@ -47,17 +154,15 @@ export default function Form({ title }: { title: string }) {
         <S.FormRightInner>
           <Input
             type="text"
-            id="label"
             width={904}
-            value={labelText || ''}
+            value={openFormValue.labelText || ''}
             placeholder="레이블 이름"
             onChange={handleLabelText}
           />
           <Input
             type="text"
-            id="description"
             width={904}
-            value={descriptionText || ''}
+            value={openFormValue.descriptionText || ''}
             placeholder="설명(선택)"
             onChange={handleDescriptionText}
           />
@@ -65,30 +170,118 @@ export default function Form({ title }: { title: string }) {
             <S.ColorWrapper>
               <Input
                 type="text"
-                id="color"
-                value={bgColor || ''}
+                value={openFormValue.bgColor || ''}
                 width={240}
                 placeholder="배경 색상"
+                onClick={onColorPopup}
+                onChange={onChangeColor}
+                maxLength={7}
               />
               <S.RefreshButton type="button" onClick={handleBgColor}>
-                <I.Refresh color="#6E7191" />
+                <I.Refresh color={openFormValue.bgColor} />
               </S.RefreshButton>
+              <div
+                ref={ref}
+                css={css`
+                  position: absolute;
+                  left: 0;
+                  top: 3rem;
+                `}
+              >
+                {isComponentVisible && (
+                  <Popup>
+                    <div
+                      css={css`
+                        margin-top: 1rem;
+                        padding: 0 1rem;
+                        ${typoXSmall(400)}
+                        ${flexbox({ ai: 'center' })}
+                      `}
+                    >
+                      Choose from default colors
+                    </div>
+                    <div
+                      css={css`
+                        padding: 0.5rem 1rem;
+                        background-color: ${theme.color.offWhite};
+                        color: ${theme.color.line};
+                        ${flexbox({ ai: 'center' })}
+                        gap: 2px;
+                        flex-wrap: wrap;
+                      `}
+                    >
+                      {defaultBgColors.map(color => (
+                        <button
+                          type="button"
+                          key={color}
+                          value={color}
+                          css={css`
+                            width: 1.5rem;
+                            height: 1.5rem;
+                            border-radius: 5px;
+                            background-color: ${color};
+                            cursor: pointer;
+                          `}
+                          onClick={handleColorClick}
+                        />
+                      ))}
+                    </div>
+                  </Popup>
+                )}
+              </div>
             </S.ColorWrapper>
             <RadioSelection.Container title="텍스트 색상">
-              <RadioSelection.Option checked onClick={handleColorText}>
-                어두운 색
-              </RadioSelection.Option>
-              <RadioSelection.Option onClick={handleColorText}>
-                밝은 색
-              </RadioSelection.Option>
+              {radioColorText.map((radioColor: string) => (
+                <RadioSelection.Option
+                  key={radioColor}
+                  checked={openFormValue.radioState === radioColor}
+                  onClick={() => handleColorText(radioColor)}
+                >
+                  {radioColor}
+                </RadioSelection.Option>
+              ))}
             </RadioSelection.Container>
           </S.FormInnerWrapper>
         </S.FormRightInner>
         <S.FormButtonWrapper>
-          <Button disabled={!complelteBtn}>
-            <I.Plus />
-            완료
-          </Button>
+          {onEdit ? (
+            <>
+              <Button
+                outlined
+                css={css`
+                  margin-right: 1rem;
+                `}
+                onClick={() => handleCloseForm(labelData?.id)}
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  initFormValue.labelText === openFormValue.labelText &&
+                  initFormValue.bgColor === openFormValue.bgColor &&
+                  initFormValue.descriptionText ===
+                    openFormValue.descriptionText &&
+                  initFormValue.radioState === openFormValue.radioState
+                }
+              >
+                <I.Edit />
+                완료
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="submit"
+              disabled={
+                openFormValue.labelText === '' ||
+                openFormValue.bgColor === '' ||
+                openFormValue.radioState === ''
+              }
+            >
+              <I.Plus />
+              완료
+            </Button>
+          )}
         </S.FormButtonWrapper>
       </S.FormContents>
     </S.FormWrapper>

--- a/FE/src/components/Label/formStyle.ts
+++ b/FE/src/components/Label/formStyle.ts
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { typoLarge, flexbox } from '@styles/mixin';
 import { moveDownAnimation, moveUpAnimation } from '@utils/animation';
 
-export const FormWrapper = styled.div`
+export const FormWrapper = styled.form`
   padding: 2rem;
   margin-bottom: 1.5rem;
   border: 1px solid;

--- a/FE/src/components/Modal/index.tsx
+++ b/FE/src/components/Modal/index.tsx
@@ -1,0 +1,19 @@
+import ReactDom from 'react-dom';
+
+import * as S from './style';
+
+interface ModalProps {
+  children: React.ReactNode;
+}
+
+export default function Modal({ children }: ModalProps) {
+  return ReactDom.createPortal(
+    <>
+      <S.ModalOverlay />
+      <S.ModalWrapper>
+        <S.ModalContent>{children}</S.ModalContent>
+      </S.ModalWrapper>
+    </>,
+    document.querySelector('#modal-root')!,
+  );
+}

--- a/FE/src/components/Modal/style.ts
+++ b/FE/src/components/Modal/style.ts
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+import { flexbox } from '@styles/mixin';
+
+export const ModalCloseBtn = styled.button`
+  border: none;
+  background: transparent;
+  cursor: pointer;
+`;
+
+export const ModalContent = styled.div`
+  position: relative;
+  top: 50%;
+  ${flexbox({ dir: 'column', ai: 'center' })};
+  padding: 2rem 3rem;
+  transform: translateY(-50%);
+  background-color: #fff;
+  box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalWrapper = styled.div`
+  position: fixed;
+  max-width: 30rem;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  margin: 0 auto;
+`;
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 999;
+  background-color: rgba(0, 0, 0, 0.6);
+`;

--- a/FE/src/components/Popup/Contents.tsx
+++ b/FE/src/components/Popup/Contents.tsx
@@ -4,7 +4,7 @@ import { IPopupData } from '@components/Popup/type';
 import theme from '@styles/theme';
 
 interface ContentsProps {
-  label: string;
+  item: string;
   popupData: IPopupData;
   handleItemClick: (
     e: React.MouseEvent<HTMLElement>,
@@ -13,7 +13,7 @@ interface ContentsProps {
 }
 
 export default function Contents({
-  label,
+  item,
   popupData,
   handleItemClick,
 }: ContentsProps) {
@@ -23,7 +23,7 @@ export default function Contents({
       className="filter__item-button"
       onClick={e => handleItemClick(e, popupData)}
     >
-      <div className="filter__item">{getModalItem(label, popupData)}</div>
+      <div className="filter__item">{getModalItem(item, popupData)}</div>
       <div className="filter__check">
         <I.Circle.Check color={theme.color.body} />
       </div>

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -39,6 +39,9 @@ export const getModalItem = (item: string, popupData: IPopupData) => {
       );
     case 'mileStone':
       return <div className="filter__name">{popupData.name}</div>;
+
+    case 'checkStatus':
+      return <div className="filter__name">{popupData.name}</div>;
     default:
       throw Error('label type not found');
   }

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 
 import { IPopupData } from '@components/Popup/type';
 
-export const getModalItem = (label: string, popupData: IPopupData) => {
-  switch (label) {
+export const getModalItem = (item: string, popupData: IPopupData) => {
+  switch (item) {
     case '이슈':
       return <div id={popupData.status}>{popupData.name}</div>;
     case 'author':

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -27,14 +27,14 @@ export const getModalItem = (label: string, popupData: IPopupData) => {
         <>
           <div
             css={css`
-              background: ${popupData.color};
+              background: ${popupData.backgroundColor};
               border-radius: 50%;
               width: 1.25rem;
               height: 1.25rem;
               margin-right: 0.5rem;
             `}
           />
-          <div className="filter__name">{popupData.name}</div>
+          <div className="filter__name">{popupData.title}</div>
         </>
       );
     case 'mileStone':

--- a/FE/src/components/Popup/type.ts
+++ b/FE/src/components/Popup/type.ts
@@ -4,9 +4,10 @@
  *  */
 
 export interface IPopupData {
-  id: number;
+  id?: number;
   imageUrl?: string;
-  status?: any;
-  color?: string;
-  name: string;
+  status?: string;
+  backgroundColor?: string;
+  title?: string;
+  name?: string;
 }

--- a/FE/src/components/SideBar/AssigneePanel.tsx
+++ b/FE/src/components/SideBar/AssigneePanel.tsx
@@ -1,0 +1,92 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import { Header } from './Common';
+import * as PopupS from './popupStyle';
+import * as S from './style';
+
+import I from '@components/Icons';
+import Popup from '@components/Popup';
+import { useAssigneePanel } from '@components/SideBar/context';
+import UserAvatar from '@components/UserAvatar';
+import useComponentVisible from '@hooks/useComponentVisible';
+
+const AssigneePanel: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const { state } = useAssigneePanel();
+  const { isComponentVisible, setIsComponentVisible, ref } =
+    useComponentVisible(false);
+
+  return (
+    <S.PanelContainer>
+      <div
+        ref={ref}
+        css={css`
+          position: relative;
+        `}
+      >
+        <Header title="담당자" onClick={() => setIsComponentVisible(p => !p)} />
+        {isComponentVisible && (
+          <AssigneePopup allowDuplicates={allowDuplicates} />
+        )}
+      </div>
+
+      <S.List>
+        {state
+          .filter(({ selected }) => selected)
+          ?.map(({ user: { userId, profileImageUrl } }) => (
+            <S.AssigneeItem key={userId}>
+              <S.AvatarWrapper>
+                <UserAvatar size="lg" src={profileImageUrl} alt={userId} />
+              </S.AvatarWrapper>
+              <S.AssigneeName>{userId}</S.AssigneeName>
+            </S.AssigneeItem>
+          ))}
+      </S.List>
+    </S.PanelContainer>
+  );
+};
+
+const AssigneePopup: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const { state: users, replaceAssignee, selectAssignee } = useAssigneePanel();
+
+  const handleClickListItem = (userId: string) => () => {
+    if (allowDuplicates) {
+      selectAssignee(userId);
+      return;
+    }
+    replaceAssignee(userId);
+  };
+
+  return (
+    <PopupS.PopupContainer>
+      <Popup>
+        <PopupS.InnerContainer>
+          <PopupS.Header>
+            <h2>담당자 선택</h2>
+          </PopupS.Header>
+          <PopupS.List>
+            {users.map(({ user: { userId, profileImageUrl }, selected }) => (
+              <PopupS.AssigneeItem
+                selected={selected}
+                onClick={handleClickListItem(userId)}
+                key={userId}
+              >
+                <PopupS.AvatarWrapper>
+                  <UserAvatar src={profileImageUrl} alt={userId} />
+                </PopupS.AvatarWrapper>
+                <PopupS.AssigneeName>{userId}</PopupS.AssigneeName>
+                {selected ? <I.Circle.Check /> : <I.Circle.Plain />}
+              </PopupS.AssigneeItem>
+            ))}
+          </PopupS.List>
+        </PopupS.InnerContainer>
+      </Popup>
+    </PopupS.PopupContainer>
+  );
+};
+
+export default AssigneePanel;

--- a/FE/src/components/SideBar/Common.tsx
+++ b/FE/src/components/SideBar/Common.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import I from '@components/Icons';
+import * as S from '@components/SideBar/style';
+
+export const Header: React.FC<{
+  title: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+}> = ({ title, onClick }) => (
+  <S.Header onClick={onClick}>
+    <S.Title>{title}</S.Title>
+    <S.SelectButton type="button">
+      <I.Plus />
+    </S.SelectButton>
+  </S.Header>
+);

--- a/FE/src/components/SideBar/LabelPanel.tsx
+++ b/FE/src/components/SideBar/LabelPanel.tsx
@@ -1,0 +1,98 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import I from '@components/Icons';
+import { Label } from '@components/Label';
+import Popup from '@components/Popup';
+import { Header } from '@components/SideBar/Common';
+import { useLabelPanel } from '@components/SideBar/context';
+import * as PopupS from '@components/SideBar/popupStyle';
+import * as S from '@components/SideBar/style';
+import UserAvatar from '@components/UserAvatar';
+import useComponentVisible from '@hooks/useComponentVisible';
+
+const COLOR = {
+  BLACK: 'BLACK',
+};
+
+const LabelPanel: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const { state } = useLabelPanel();
+  const { isComponentVisible, setIsComponentVisible, ref } =
+    useComponentVisible(false);
+
+  return (
+    <S.PanelContainer>
+      <div
+        ref={ref}
+        css={css`
+          position: relative;
+        `}
+      >
+        <Header title="레이블" onClick={() => setIsComponentVisible(p => !p)} />
+        {isComponentVisible && <LabelPopup allowDuplicates={allowDuplicates} />}
+      </div>
+
+      <S.List>
+        {state
+          .filter(({ selected }) => selected)
+          ?.map(({ label: { id, title, backgroundColor, textColor } }) => (
+            <S.LabelItem key={id}>
+              <Label
+                bgColor={backgroundColor}
+                darkText={textColor === COLOR.BLACK}
+              >
+                {title}
+              </Label>
+            </S.LabelItem>
+          ))}
+      </S.List>
+    </S.PanelContainer>
+  );
+};
+
+const LabelPopup: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const { state: labels, replaceLabel, selectLabel } = useLabelPanel();
+
+  const handleClickListItem = (labelId: number) => () => {
+    if (allowDuplicates) {
+      selectLabel(labelId);
+      return;
+    }
+    replaceLabel(labelId);
+  };
+
+  return (
+    <PopupS.PopupContainer>
+      <Popup>
+        <PopupS.InnerContainer>
+          <PopupS.Header>
+            <h2>레이블 선택</h2>
+          </PopupS.Header>
+          <PopupS.List>
+            {labels.map(
+              ({ label: { id, backgroundColor, title }, selected }) => (
+                <PopupS.ItemCommon
+                  selected={selected}
+                  onClick={handleClickListItem(id)}
+                  key={id}
+                >
+                  <PopupS.AvatarWrapper>
+                    <UserAvatar fill={backgroundColor} src="" alt={title} />
+                  </PopupS.AvatarWrapper>
+                  <PopupS.LabelTitle>{title}</PopupS.LabelTitle>
+                  {selected ? <I.Circle.Check /> : <I.Circle.Plain />}
+                </PopupS.ItemCommon>
+              ),
+            )}
+          </PopupS.List>
+        </PopupS.InnerContainer>
+      </Popup>
+    </PopupS.PopupContainer>
+  );
+};
+
+export default LabelPanel;

--- a/FE/src/components/SideBar/MileStonePanel.tsx
+++ b/FE/src/components/SideBar/MileStonePanel.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import I from '@components/Icons';
+import { ProgressBar } from '@components/Indicator/ProgressBar';
+import Popup from '@components/Popup';
+import { Header } from '@components/SideBar/Common';
+import { useMileStonePanel } from '@components/SideBar/context';
+import * as PopupS from '@components/SideBar/popupStyle';
+import * as S from '@components/SideBar/style';
+import useComponentVisible from '@hooks/useComponentVisible';
+
+const MileStonePanel: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const { state } = useMileStonePanel();
+  const { isComponentVisible, setIsComponentVisible, ref } =
+    useComponentVisible(false);
+
+  return (
+    <S.PanelContainer>
+      <div
+        ref={ref}
+        css={css`
+          position: relative;
+        `}
+      >
+        <Header
+          title="마일스톤"
+          onClick={() => setIsComponentVisible(p => !p)}
+        />
+        {isComponentVisible && (
+          <MileStonePopup allowDuplicates={allowDuplicates} />
+        )}
+      </div>
+
+      <S.List>
+        {state
+          .filter(({ selected }) => selected)
+          ?.map(({ milestone: { id, title, progressRate } }) => (
+            <S.MileStoneItem key={id}>
+              <ProgressBar width={progressRate} />
+              <S.MileStoneTitle>{title}</S.MileStoneTitle>
+            </S.MileStoneItem>
+          ))}
+      </S.List>
+    </S.PanelContainer>
+  );
+};
+
+const MileStonePopup: React.FC<{ allowDuplicates?: boolean }> = ({
+  allowDuplicates = false,
+}) => {
+  const {
+    state: milestones,
+    replaceMileStone,
+    selectMileStone,
+  } = useMileStonePanel();
+
+  const handleClickListItem = (milestoneId: number) => () => {
+    if (allowDuplicates) {
+      selectMileStone(milestoneId);
+      return;
+    }
+    replaceMileStone(milestoneId);
+  };
+
+  return (
+    <PopupS.PopupContainer>
+      <Popup>
+        <PopupS.InnerContainer>
+          <PopupS.Header>
+            <h2>마일스톤 선택</h2>
+          </PopupS.Header>
+          <PopupS.List>
+            {milestones.map(({ milestone: { id, title }, selected }) => (
+              <PopupS.ItemCommon
+                selected={selected}
+                onClick={handleClickListItem(id)}
+                key={id}
+              >
+                <PopupS.MileStoneTitle>{title}</PopupS.MileStoneTitle>
+                {selected ? <I.Circle.Check /> : <I.Circle.Plain />}
+              </PopupS.ItemCommon>
+            ))}
+          </PopupS.List>
+        </PopupS.InnerContainer>
+      </Popup>
+    </PopupS.PopupContainer>
+  );
+};
+
+export default MileStonePanel;

--- a/FE/src/components/SideBar/context/AssigneePanel/index.tsx
+++ b/FE/src/components/SideBar/context/AssigneePanel/index.tsx
@@ -1,0 +1,162 @@
+import React, {
+  useContext,
+  createContext,
+  useReducer,
+  useMemo,
+  useCallback,
+} from 'react';
+
+import { User } from '@type/user';
+
+type AssigneePanelState = Array<{ user: User; selected: boolean }>;
+
+type AssigneePanelAction =
+  | { type: 'INIT_PANEL'; payload: { users: User[] } }
+  | { type: 'SELECT_ASSIGNEE'; payload: { userId: string } }
+  | { type: 'REPLACE_ASSIGNEE'; payload: { userId: string } };
+type AssigneePanelDispatch = React.Dispatch<AssigneePanelAction>;
+
+const initialState: AssigneePanelState = [];
+
+const AssigneePanelContext = createContext<AssigneePanelState | null>(null);
+
+const AssigneePanelDispatchContext =
+  createContext<AssigneePanelDispatch | null>(null);
+
+const assigneePanelReducer = (
+  state: AssigneePanelState,
+  action: AssigneePanelAction,
+) => {
+  switch (action.type) {
+    case 'INIT_PANEL': {
+      const { users } = action.payload;
+      if (!users) {
+        return state;
+      }
+
+      return users.map(user => ({ user, selected: false }));
+    }
+
+    // 다중 선택 가능할때 사용.
+    case 'SELECT_ASSIGNEE': {
+      const { userId } = action.payload;
+
+      return state.map(element =>
+        element.user.userId === userId
+          ? { user: element.user, selected: !element.selected }
+          : element,
+      );
+    }
+
+    // 다중 선택 불가능할때 사용.
+    case 'REPLACE_ASSIGNEE': {
+      const { userId } = action.payload;
+
+      return state.map(element =>
+        element.user.userId === userId
+          ? { user: element.user, selected: !element.selected }
+          : { user: element.user, selected: false },
+      );
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+// action creator
+const initPanelAction = (
+  users: User[],
+): { type: 'INIT_PANEL'; payload: { users: User[] } } => ({
+  type: 'INIT_PANEL',
+  payload: { users },
+});
+
+const selectAssigneeAction = (
+  userId: string,
+): { type: 'SELECT_ASSIGNEE'; payload: { userId: string } } => ({
+  type: 'SELECT_ASSIGNEE',
+  payload: { userId },
+});
+
+const replaceAssigneeAction = (
+  userId: string,
+): { type: 'REPLACE_ASSIGNEE'; payload: { userId: string } } => ({
+  type: 'REPLACE_ASSIGNEE',
+  payload: { userId },
+});
+
+export const AssigneePanelProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(assigneePanelReducer, initialState);
+
+  const memorizedState = useMemo(() => state, [state]);
+
+  return (
+    <AssigneePanelDispatchContext.Provider value={dispatch}>
+      <AssigneePanelContext.Provider value={memorizedState}>
+        {children}
+      </AssigneePanelContext.Provider>
+    </AssigneePanelDispatchContext.Provider>
+  );
+};
+
+export const useAssigneePanel = () => {
+  const state = useContext(AssigneePanelContext);
+  const dispatch = useContext(AssigneePanelDispatchContext);
+
+  if (state === null || dispatch === null) {
+    throw Error(
+      'Assignee Panel Provider Or Assignee Panel Dispatch Provider Error',
+    );
+  }
+
+  const initPanel = useCallback((users: User[] = []) => {
+    dispatch(initPanelAction(users));
+  }, []);
+
+  const selectAssignee = useCallback((userId: string) => {
+    dispatch(selectAssigneeAction(userId));
+  }, []);
+
+  const replaceAssignee = useCallback((userId: string) => {
+    dispatch(replaceAssigneeAction(userId));
+  }, []);
+
+  return { state, initPanel, selectAssignee, replaceAssignee };
+};
+
+export const useAssigneePanelState = () => {
+  const state = useContext(AssigneePanelContext);
+
+  if (state === null) {
+    throw Error('Assignee Panel Provider Error');
+  }
+
+  return state;
+};
+
+export const useSetAssigneePanelState = () => {
+  const dispatch = useContext(AssigneePanelDispatchContext);
+  if (dispatch === null) {
+    throw Error('Assignee Panel Dispatch Provider Error');
+  }
+
+  const initPanel = useCallback((users: User[] = []) => {
+    dispatch(initPanelAction(users));
+  }, []);
+
+  const selectAssignee = useCallback((userId: string) => {
+    dispatch(selectAssigneeAction(userId));
+  }, []);
+
+  const replaceAssignee = useCallback((userId: string) => {
+    dispatch(replaceAssigneeAction(userId));
+  }, []);
+
+  return { initPanel, selectAssignee, replaceAssignee };
+};

--- a/FE/src/components/SideBar/context/LabelPanel/index.tsx
+++ b/FE/src/components/SideBar/context/LabelPanel/index.tsx
@@ -1,0 +1,161 @@
+import React, {
+  useContext,
+  createContext,
+  useReducer,
+  useMemo,
+  useCallback,
+} from 'react';
+
+import { Label } from '@type/label';
+
+type LabelPanelState = Array<{ label: Label; selected: boolean }>;
+
+type LabelPanelAction =
+  | { type: 'INIT_PANEL'; payload: { labels: Label[] } }
+  | { type: 'SELECT_LABEL'; payload: { labelId: number } }
+  | { type: 'REPLACE_LABEL'; payload: { labelId: number } };
+type LabelPanelDispatch = React.Dispatch<LabelPanelAction>;
+
+const initialState: LabelPanelState = [];
+
+const LabelPanelContext = createContext<LabelPanelState | null>(null);
+
+const LabelPanelDispatchContext = createContext<LabelPanelDispatch | null>(
+  null,
+);
+
+const labelPanelReducer = (
+  state: LabelPanelState,
+  action: LabelPanelAction,
+) => {
+  switch (action.type) {
+    case 'INIT_PANEL': {
+      const { labels } = action.payload;
+      if (!labels) {
+        return state;
+      }
+
+      return labels.map(label => ({ label, selected: false }));
+    }
+
+    // 다중 선택 가능할때 사용.
+    case 'SELECT_LABEL': {
+      const { labelId } = action.payload;
+
+      return state.map(element =>
+        element.label.id === labelId
+          ? { label: element.label, selected: !element.selected }
+          : element,
+      );
+    }
+
+    // 다중 선택 불가능할때 사용.
+    case 'REPLACE_LABEL': {
+      const { labelId } = action.payload;
+
+      return state.map(element =>
+        element.label.id === labelId
+          ? { label: element.label, selected: !element.selected }
+          : { label: element.label, selected: false },
+      );
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+// action creator
+const initPanelAction = (
+  labels: Label[],
+): { type: 'INIT_PANEL'; payload: { labels: Label[] } } => ({
+  type: 'INIT_PANEL',
+  payload: { labels },
+});
+
+const selectLabelAction = (
+  labelId: number,
+): { type: 'SELECT_LABEL'; payload: { labelId: number } } => ({
+  type: 'SELECT_LABEL',
+  payload: { labelId },
+});
+
+const replaceLabelAction = (
+  labelId: number,
+): { type: 'REPLACE_LABEL'; payload: { labelId: number } } => ({
+  type: 'REPLACE_LABEL',
+  payload: { labelId },
+});
+
+export const LabelPanelProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(labelPanelReducer, initialState);
+
+  const memorizedState = useMemo(() => state, [state]);
+
+  return (
+    <LabelPanelDispatchContext.Provider value={dispatch}>
+      <LabelPanelContext.Provider value={memorizedState}>
+        {children}
+      </LabelPanelContext.Provider>
+    </LabelPanelDispatchContext.Provider>
+  );
+};
+
+export const useLabelPanel = () => {
+  const state = useContext(LabelPanelContext);
+  const dispatch = useContext(LabelPanelDispatchContext);
+
+  if (state === null || dispatch === null) {
+    throw Error('Label Panel Provider Or Label Panel Dispatch Provider Error');
+  }
+
+  const initPanel = useCallback((labels: Label[] = []) => {
+    dispatch(initPanelAction(labels));
+  }, []);
+
+  const selectLabel = useCallback((labelId: number) => {
+    dispatch(selectLabelAction(labelId));
+  }, []);
+
+  const replaceLabel = useCallback((labelId: number) => {
+    dispatch(replaceLabelAction(labelId));
+  }, []);
+
+  return { state, initPanel, selectLabel, replaceLabel };
+};
+
+export const useLabelPanelState = () => {
+  const state = useContext(LabelPanelContext);
+
+  if (state === null) {
+    throw Error('Label Panel Provider Error');
+  }
+
+  return state;
+};
+
+export const useSetLabelPanelState = () => {
+  const dispatch = useContext(LabelPanelDispatchContext);
+  if (dispatch === null) {
+    throw Error('Label Panel Dispatch Provider Error');
+  }
+
+  const initPanel = useCallback((labels: Label[] = []) => {
+    dispatch(initPanelAction(labels));
+  }, []);
+
+  const selectLabel = useCallback((labelId: number) => {
+    dispatch(selectLabelAction(labelId));
+  }, []);
+
+  const replaceLabel = useCallback((labelId: number) => {
+    dispatch(replaceLabelAction(labelId));
+  }, []);
+
+  return { initPanel, selectLabel, replaceLabel };
+};

--- a/FE/src/components/SideBar/context/MileStonePanel/index.tsx
+++ b/FE/src/components/SideBar/context/MileStonePanel/index.tsx
@@ -1,0 +1,162 @@
+import React, {
+  useContext,
+  createContext,
+  useReducer,
+  useMemo,
+  useCallback,
+} from 'react';
+
+import { MileStone } from '@type/milestone';
+
+type MileStonePanelState = Array<{ milestone: MileStone; selected: boolean }>;
+
+type MileStonePanelAction =
+  | { type: 'INIT_PANEL'; payload: { milestones: MileStone[] } }
+  | { type: 'SELECT_MILESTONE'; payload: { milestoneId: number } }
+  | { type: 'REPLACE_MILESTONE'; payload: { milestoneId: number } };
+type MileStonePanelDispatch = React.Dispatch<MileStonePanelAction>;
+
+const initialState: MileStonePanelState = [];
+
+const MileStonePanelContext = createContext<MileStonePanelState | null>(null);
+
+const MileStonePanelDispatchContext =
+  createContext<MileStonePanelDispatch | null>(null);
+
+const milestonePanelReducer = (
+  state: MileStonePanelState,
+  action: MileStonePanelAction,
+) => {
+  switch (action.type) {
+    case 'INIT_PANEL': {
+      const { milestones } = action.payload;
+      if (!milestones) {
+        return state;
+      }
+
+      return milestones.map(milestone => ({ milestone, selected: false }));
+    }
+
+    // 다중 선택 가능할때 사용.
+    case 'SELECT_MILESTONE': {
+      const { milestoneId } = action.payload;
+
+      return state.map(element =>
+        element.milestone.id === milestoneId
+          ? { milestone: element.milestone, selected: !element.selected }
+          : element,
+      );
+    }
+
+    // 다중 선택 불가능할때 사용.
+    case 'REPLACE_MILESTONE': {
+      const { milestoneId } = action.payload;
+
+      return state.map(element =>
+        element.milestone.id === milestoneId
+          ? { milestone: element.milestone, selected: !element.selected }
+          : { milestone: element.milestone, selected: false },
+      );
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+// action creator
+const initPanelAction = (
+  milestones: MileStone[],
+): { type: 'INIT_PANEL'; payload: { milestones: MileStone[] } } => ({
+  type: 'INIT_PANEL',
+  payload: { milestones },
+});
+
+const selectMileStoneAction = (
+  milestoneId: number,
+): { type: 'SELECT_MILESTONE'; payload: { milestoneId: number } } => ({
+  type: 'SELECT_MILESTONE',
+  payload: { milestoneId },
+});
+
+const replaceMileStoneAction = (
+  milestoneId: number,
+): { type: 'REPLACE_MILESTONE'; payload: { milestoneId: number } } => ({
+  type: 'REPLACE_MILESTONE',
+  payload: { milestoneId },
+});
+
+export const MileStonePanelProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(milestonePanelReducer, initialState);
+
+  const memorizedState = useMemo(() => state, [state]);
+
+  return (
+    <MileStonePanelDispatchContext.Provider value={dispatch}>
+      <MileStonePanelContext.Provider value={memorizedState}>
+        {children}
+      </MileStonePanelContext.Provider>
+    </MileStonePanelDispatchContext.Provider>
+  );
+};
+
+export const useMileStonePanel = () => {
+  const state = useContext(MileStonePanelContext);
+  const dispatch = useContext(MileStonePanelDispatchContext);
+
+  if (state === null || dispatch === null) {
+    throw Error(
+      'MileStone Panel Provider Or MileStone Panel Dispatch Provider Error',
+    );
+  }
+
+  const initPanel = useCallback((milestones: MileStone[] = []) => {
+    dispatch(initPanelAction(milestones));
+  }, []);
+
+  const selectMileStone = useCallback((milestoneId: number) => {
+    dispatch(selectMileStoneAction(milestoneId));
+  }, []);
+
+  const replaceMileStone = useCallback((milestoneId: number) => {
+    dispatch(replaceMileStoneAction(milestoneId));
+  }, []);
+
+  return { state, initPanel, selectMileStone, replaceMileStone };
+};
+
+export const useMileStonePanelState = () => {
+  const state = useContext(MileStonePanelContext);
+
+  if (state === null) {
+    throw Error('MileStone Panel Provider Error');
+  }
+
+  return state;
+};
+
+export const useSetMileStonePanelState = () => {
+  const dispatch = useContext(MileStonePanelDispatchContext);
+  if (dispatch === null) {
+    throw Error('MileStone Panel Dispatch Provider Error');
+  }
+
+  const initPanel = useCallback((milestones: MileStone[] = []) => {
+    dispatch(initPanelAction(milestones));
+  }, []);
+
+  const selectMileStone = useCallback((milestoneId: number) => {
+    dispatch(selectMileStoneAction(milestoneId));
+  }, []);
+
+  const replaceMileStone = useCallback((milestoneId: number) => {
+    dispatch(replaceMileStoneAction(milestoneId));
+  }, []);
+
+  return { initPanel, selectMileStone, replaceMileStone };
+};

--- a/FE/src/components/SideBar/context/index.tsx
+++ b/FE/src/components/SideBar/context/index.tsx
@@ -1,0 +1,20 @@
+export {
+  useAssigneePanel,
+  useAssigneePanelState,
+  useSetAssigneePanelState,
+  AssigneePanelProvider,
+} from './AssigneePanel';
+
+export {
+  useLabelPanel,
+  useLabelPanelState,
+  useSetLabelPanelState,
+  LabelPanelProvider,
+} from './LabelPanel';
+
+export {
+  useMileStonePanel,
+  useMileStonePanelState,
+  useSetMileStonePanelState,
+  MileStonePanelProvider,
+} from './MileStonePanel';

--- a/FE/src/components/SideBar/context/index.tsx
+++ b/FE/src/components/SideBar/context/index.tsx
@@ -1,20 +1,43 @@
+import React from 'react';
+
+import { AssigneePanelProvider } from './AssigneePanel';
+import { LabelPanelProvider } from './LabelPanel';
+import { MileStonePanelProvider } from './MileStonePanel';
+
+import Compose from '@utils/Compose';
+
 export {
   useAssigneePanel,
   useAssigneePanelState,
   useSetAssigneePanelState,
-  AssigneePanelProvider,
 } from './AssigneePanel';
 
 export {
   useLabelPanel,
   useLabelPanelState,
   useSetLabelPanelState,
-  LabelPanelProvider,
 } from './LabelPanel';
 
 export {
   useMileStonePanel,
   useMileStonePanelState,
   useSetMileStonePanelState,
-  MileStonePanelProvider,
 } from './MileStonePanel';
+
+export { AssigneePanelProvider, LabelPanelProvider, MileStonePanelProvider };
+
+export const SideBarProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => (
+  <Compose
+    components={[
+      AssigneePanelProvider,
+      LabelPanelProvider,
+      MileStonePanelProvider,
+    ]}
+  >
+    {children}
+  </Compose>
+);

--- a/FE/src/components/SideBar/index.tsx
+++ b/FE/src/components/SideBar/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import AssigneePanel from './AssigneePanel';
+import LabelPanel from './LabelPanel';
+import MileStonePanel from './MileStonePanel';
+import * as S from './style';
+
+const Container: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <S.Container>{children}</S.Container>
+);
+
+export default {
+  Container,
+  AssigneePanel,
+  LabelPanel,
+  MileStonePanel,
+};

--- a/FE/src/components/SideBar/popupStyle.ts
+++ b/FE/src/components/SideBar/popupStyle.ts
@@ -37,7 +37,7 @@ export const ItemCommon = styled.li<{ selected: boolean }>`
     background-color: ${({ theme }) => theme.color.background};
   }
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     border-top: 1px solid ${({ theme }) => theme.color.line};
   }
 `;

--- a/FE/src/components/SideBar/popupStyle.ts
+++ b/FE/src/components/SideBar/popupStyle.ts
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+
+import { flexbox, typoSmall } from '@styles/mixin';
+
+export const PopupContainer = styled.div`
+  z-index: ${({ theme }) => theme.zIndex.sideBar.popup};
+  position: absolute;
+  top: 2rem;
+  right: -0.5rem;
+`;
+
+export const InnerContainer = styled.div`
+  max-height: 18rem;
+  overflow-y: scroll;
+`;
+
+export const Header = styled.header`
+  background-color: ${({ theme }) => theme.color.background};
+  border-bottom: 1px solid ${({ theme }) => theme.color.line};
+  position: sticky;
+  top: 0;
+`;
+
+export const List = styled.ul``;
+
+export const ItemCommon = styled.li<{ selected: boolean }>`
+  ${flexbox({ ai: 'center' })}
+  height: 2.75rem;
+  padding: 0 1rem;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.color.offWhite};
+  color: ${({ theme, selected }) =>
+    selected ? theme.color.titleActive : theme.color.body};
+  transition: background-color 250ms;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.background};
+  }
+
+  &:not(:first-child) {
+    border-top: 1px solid ${({ theme }) => theme.color.line};
+  }
+`;
+
+export const TitleCommon = styled.p`
+  ${typoSmall(400)};
+  margin-left: 0.5rem;
+  flex-grow: 1;
+  word-break: break-all;
+`;
+
+export const AssigneeItem = styled(ItemCommon)``;
+
+export const AvatarWrapper = styled.div`
+  flex-shrink: 0;
+`;
+
+export const AssigneeName = styled(TitleCommon)``;
+
+export const LabelTitle = styled(TitleCommon)``;
+
+export const MileStoneTitle = styled(TitleCommon)``;

--- a/FE/src/components/SideBar/style.ts
+++ b/FE/src/components/SideBar/style.ts
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+
+import { flexbox, simpleOpacityTransition, typoSmall } from '@styles/mixin';
+
+export const Container = styled.div`
+  display: inline-block;
+  border-radius: 1rem;
+  border: 1px solid ${({ theme }) => theme.color.line};
+  background-color: ${({ theme }) => theme.color.offWhite};
+`;
+
+export const PanelContainer = styled.div`
+  padding: 2rem;
+  width: 19.25rem;
+
+  & + & {
+    border-top: 1px solid ${({ theme }) => theme.color.line};
+  }
+`;
+
+export const Header = styled.header`
+  ${flexbox({ ai: 'center' })};
+  ${typoSmall(700)}
+  cursor: pointer;
+  color: ${({ theme }) => theme.color.label};
+  height: 2rem;
+  ${simpleOpacityTransition({
+    delay: 100,
+    hoverOpacity: 0.7,
+    activeOpacity: 0.9,
+  })}
+`;
+
+export const SelectButton = styled.button`
+  background-color: transparent;
+  ${typoSmall(700)}
+  color: inherit;
+`;
+
+export const Title = styled.h2`
+  flex-grow: 1;
+  margin-right: 0.25rem;
+`;
+
+export const List = styled.ul``;
+
+export const ItemCommon = styled.li`
+  ${flexbox({ ai: 'center' })};
+  word-break: break-all;
+  margin-top: 1rem;
+`;
+
+export const TitleCommon = styled.p`
+  ${typoSmall(400)};
+  color: ${({ theme }) => theme.color.label};
+`;
+
+export const AssigneeItem = styled(ItemCommon)``;
+
+export const AvatarWrapper = styled.div`
+  flex-shrink: 0;
+`;
+
+export const AssigneeName = styled(TitleCommon)`
+  margin-left: 0.25rem;
+`;
+
+export const LabelItem = styled(ItemCommon)`
+  height: 1.75rem;
+`;
+
+export const MileStoneItem = styled(ItemCommon)`
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+export const MileStoneTitle = styled(TitleCommon)`
+  margin-top: 0.25rem;
+`;

--- a/FE/src/components/UserAvatar/index.tsx
+++ b/FE/src/components/UserAvatar/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   src: string;
   size?: 'sm' | 'lg';
   alt?: string;
+  fill?: string;
 }
 
 // T라는 리액트 엘리먼트의 props와 위에 정의한 Props의 props, as props를 가지는 type
@@ -17,11 +18,12 @@ const UserAvatar = <T extends React.ElementType = 'div'>({
   alt = '',
   size = 'sm',
   src,
+  fill,
   as,
   ...restProps
 }: UserAvatarProps<T>) => (
-  <S.UserAvatar as={as ?? 'div'} size={size} {...restProps}>
-    <S.Image src={src} alt={alt} />
+  <S.UserAvatar as={as ?? 'div'} size={size} fill={fill} {...restProps}>
+    {fill ? <S.Fill fill={fill} /> : <S.Image src={src} alt={alt} />}
   </S.UserAvatar>
 );
 

--- a/FE/src/components/UserAvatar/index.tsx
+++ b/FE/src/components/UserAvatar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import * as S from './style';
 
@@ -25,4 +25,4 @@ const UserAvatar = <T extends React.ElementType = 'div'>({
   </S.UserAvatar>
 );
 
-export default UserAvatar;
+export default memo(UserAvatar);

--- a/FE/src/components/UserAvatar/style.ts
+++ b/FE/src/components/UserAvatar/style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-export const UserAvatar = styled.button<{ size: 'sm' | 'lg' }>`
+export const UserAvatar = styled.button<{ size: 'sm' | 'lg'; fill?: string }>`
   border-style: solid;
-  border-color: ${({ theme }) => theme.color.body};
+  border-color: ${({ theme, fill }) => fill || theme.color.body};
   border-width: ${({ size }) => (size === 'sm' ? 1 : 2)}px;
   border-radius: 50%;
   overflow: hidden;
@@ -24,4 +24,10 @@ export const Image = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+`;
+
+export const Fill = styled.div<{ fill?: string }>`
+  width: 100%;
+  height: 100%;
+  background-color: ${({ fill }) => fill};
 `;

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -2,7 +2,7 @@ export const defaultProfileImageUrl =
   'https://www.stignatius.co.uk/wp-content/uploads/2020/10/default-user-icon.jpg';
 
 export const searchDebounceDelay = 300;
-export const limitedLengthSearchValue = 40;
+export const limitedLengthSearchValue = 60;
 export const radioColorText = ['어두운색', '밝은색'];
 export const initBgColor = '#EFF0F6';
 export const defaultBgColors = [

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -3,3 +3,23 @@ export const defaultProfileImageUrl =
 
 export const searchDebounceDelay = 300;
 export const limitedLengthSearchValue = 40;
+export const radioColorText = ['어두운색', '밝은색'];
+export const initBgColor = '#EFF0F6';
+export const defaultBgColors = [
+  '#B60205',
+  '#D93F0B',
+  '#FBCA04',
+  '#0E8A16',
+  '#006B75',
+  '#1D76DB',
+  '#0052CC',
+  '#5319E7',
+  '#E99695',
+  '#F9D0C4',
+  '#FEF2C0',
+  '#C2E0C6',
+  '#BFDADC',
+  '#C5DEF5',
+  '#BFD4F2',
+  '#D4C5F9',
+];

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -1,2 +1,5 @@
 export const defaultProfileImageUrl =
   'https://www.stignatius.co.uk/wp-content/uploads/2020/10/default-user-icon.jpg';
+
+export const searchDebounceDelay = 300;
+export const limitedLengthSearchValue = 40;

--- a/FE/src/hooks/useComponentVisible.tsx
+++ b/FE/src/hooks/useComponentVisible.tsx
@@ -3,11 +3,13 @@ import React, { useState, useEffect, useRef } from 'react';
 export default function useComponentVisible(initialIsVisible: boolean) {
   const [isComponentVisible, setIsComponentVisible] =
     useState(initialIsVisible);
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const handleClickOutside = (e: React.MouseEvent): void => {
+  const handleClickOutside = (
+    e: React.BaseSyntheticEvent | MouseEvent,
+  ): void => {
     if (ref.current) {
-      if (!ref.current.contains(e.target as HTMLElement)) {
+      if (!ref.current.contains(e.target)) {
         setIsComponentVisible(false);
       }
     }

--- a/FE/src/hooks/useDebouce.tsx
+++ b/FE/src/hooks/useDebouce.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce(value: string, delay: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/FE/src/hooks/useInput.tsx
+++ b/FE/src/hooks/useInput.tsx
@@ -1,0 +1,10 @@
+import React, { useState } from 'react';
+
+export const useInput = () => {
+  const [value, setValue] = useState('');
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return { value, onChange };
+};

--- a/FE/src/hooks/usePostIssue.tsx
+++ b/FE/src/hooks/usePostIssue.tsx
@@ -1,0 +1,22 @@
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postIssue } from '@apis/issue';
+
+export const usePostIssue = () => {
+  const navigate = useNavigate();
+  const { mutate, isLoading } = useMutation(
+    (requestBody: any) => postIssue(requestBody),
+    {
+      onSuccess: data => {
+        globalThis.alert('이슈를 성공적으로 등록하였습니다!');
+        navigate(`/issue/${data.issueId}`);
+      },
+      onError: () => {
+        globalThis.alert('이슈 등록에 실패했습니다.');
+      },
+    },
+  );
+
+  return { mutate, isLoading };
+};

--- a/FE/src/mocks/handlers/GetLabels.js
+++ b/FE/src/mocks/handlers/GetLabels.js
@@ -1,0 +1,33 @@
+import { rest } from 'msw';
+
+export const GetLabels = rest.get(
+  `${process.env.TEAM30_BASE_URL}/api/labels`,
+  (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json([
+        {
+          id: 81,
+          backgroundColor: '#F7F7FC',
+          title: 'duplicate',
+          description: 'duplicate Des',
+          textColor: 'BLACK',
+        },
+        {
+          id: 82,
+          backgroundColor: '#004DE3',
+          title: 'documentation',
+          description: 'documentation Des',
+          textColor: 'WHITE',
+        },
+        {
+          id: 83,
+          backgroundColor: '#C60B00',
+          title: 'bug',
+          description: 'bug Des',
+          textColor: 'WHITE',
+        },
+      ]),
+    ),
+);

--- a/FE/src/mocks/handlers/GetMileStones.js
+++ b/FE/src/mocks/handlers/GetMileStones.js
@@ -1,0 +1,39 @@
+import { rest } from 'msw';
+
+export const GetMileStones = rest.get(
+  `${process.env.TEAM30_BASE_URL}/api/milestones`,
+  (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.delay(0),
+      ctx.json([
+        {
+          id: 31,
+          title: '1주차 마일스톤',
+          description: '',
+          createdAt: '2022-06-25T02:11:32.883Z',
+          updatedAt: '2022-06-26T02:11:32.883Z',
+          dueDate: '2022-06-29',
+          progressRate: 42,
+        },
+        {
+          id: 32,
+          title: '2주차 마일스톤',
+          description: '',
+          createdAt: '2022-06-27T02:11:32.883Z',
+          updatedAt: '2022-06-28T02:11:32.883Z',
+          dueDate: '2022-06-29',
+          progressRate: 56,
+        },
+        {
+          id: 33,
+          title: '3주차 마일스톤',
+          description: 'dsfhgpoqke',
+          createdAt: '2022-06-29T02:11:32.883Z',
+          updatedAt: '2022-06-29T02:11:32.883Z',
+          dueDate: '2022-07-01',
+          progressRate: 7,
+        },
+      ]),
+    ),
+);

--- a/FE/src/mocks/handlers/GetUsers.js
+++ b/FE/src/mocks/handlers/GetUsers.js
@@ -1,0 +1,30 @@
+import { rest } from 'msw';
+
+export const GetUsers = rest.get(
+  `${process.env.TEAM30_BASE_URL}/users`,
+  (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.delay(0),
+      ctx.json([
+        {
+          userId: 'mjsdo',
+          userName: 'abc',
+          profileImageUrl:
+            'https://avatars.githubusercontent.com/u/79135734?s=96&v=4',
+        },
+        {
+          userId: 'muffin',
+          userName: 'def',
+          profileImageUrl:
+            'https://avatars.githubusercontent.com/u/45479309?v=4',
+        },
+        {
+          userId: 'nathan29849',
+          userName: 'ghi',
+          profileImageUrl:
+            'https://avatars.githubusercontent.com/u/67811880?v=4',
+        },
+      ]),
+    ),
+);

--- a/FE/src/mocks/handlers/PostIssue.js
+++ b/FE/src/mocks/handlers/PostIssue.js
@@ -1,0 +1,15 @@
+import { rest } from 'msw';
+
+export const PostIssue = rest.post(
+  `${process.env.TEAM30_BASE_URL}/api/issues`,
+  (req, res, ctx) => {
+    console.log(req.body);
+    return res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json({
+        issueId: 1,
+      }),
+    );
+  },
+);

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -1,6 +1,9 @@
 // src/mocks/handlers.js
 import { rest } from 'msw';
 
+import { GetLabels } from './GetLabels';
+import { GetMileStones } from './GetMileStones';
+import { GetUsers } from './GetUsers';
 import { GitHubLogin, RefreshGitHubLogin } from './GitHubLogin';
 import { PostIssue } from './PostIssue';
 
@@ -97,7 +100,10 @@ export const handlers = [
   getIssue,
   getLable,
   postLabel,
+  GetLabels,
   GitHubLogin,
   RefreshGitHubLogin,
   PostIssue,
+  GetUsers,
+  GetMileStones,
 ];

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -52,30 +52,51 @@ const getLable = rest.get('/issue/label', (req, res, ctx) =>
     ctx.delay(1000),
     ctx.json([
       {
-        id: 1,
-        color: '#F7F7FC',
-        name: 'duplicate',
-        darkText: true,
+        id: 81,
+        backgroundColor: '#F7F7FC',
+        title: 'duplicate',
+        description: 'duplicate Des',
+        textColor: 'BLACK',
       },
       {
-        id: 2,
-        color: '#004DE3',
-        name: 'documentation',
-        darkText: false,
+        id: 82,
+        backgroundColor: '#004DE3',
+        title: 'documentation',
+        description: 'documentation Des',
+        textColor: 'WHITE',
       },
       {
-        id: 3,
-        color: '#C60B00',
-        name: 'bug',
-        darkText: false,
+        id: 83,
+        backgroundColor: '#C60B00',
+        title: 'bug',
+        description: 'bug Des',
+        textColor: 'WHITE',
       },
     ]),
   ),
 );
 
+const postLabel = rest.post('/issue/label', (req, res, ctx) => {
+  const { title, backgroundColor, description, textColor } = JSON.parse(
+    req.body,
+  );
+
+  return res(
+    ctx.status(200),
+    ctx.delay(1000),
+    ctx.json({
+      title,
+      backgroundColor,
+      description,
+      textColor,
+    }),
+  );
+});
+
 export const handlers = [
   getIssue,
   getLable,
+  postLabel,
   GitHubLogin,
   RefreshGitHubLogin,
   PostIssue,

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -2,18 +2,7 @@
 import { rest } from 'msw';
 
 import { GitHubLogin, RefreshGitHubLogin } from './GitHubLogin';
-
-const getUser = rest.get('/user', (req, res, ctx) =>
-  res(
-    ctx.status(200),
-    ctx.delay(2000),
-    ctx.json({
-      id: 120123123,
-      username: 'sadjfaioij',
-      password: 'dpofoqpwjer',
-    }),
-  ),
-);
+import { PostIssue } from './PostIssue';
 
 const getIssue = rest.get('/issue', (req, res, ctx) =>
   res(
@@ -85,9 +74,9 @@ const getLable = rest.get('/issue/label', (req, res, ctx) =>
 );
 
 export const handlers = [
-  getUser,
   getIssue,
   getLable,
   GitHubLogin,
   RefreshGitHubLogin,
+  PostIssue,
 ];

--- a/FE/src/pages/Callback/index.tsx
+++ b/FE/src/pages/Callback/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 
 import { Loader } from '@components/Indicator/Loader';
 import { useLogin } from '@hooks/useLogin';
-import theme from '@styles/theme';
+import { alignPosXY } from '@styles/mixin';
 
 function Callback() {
   const { search } = window.location;
@@ -16,8 +16,7 @@ function Callback() {
   return (
     <div
       css={css`
-        height: 100vh;
-        background-color: ${theme.color.background};
+        ${alignPosXY('fixed')}
       `}
     >
       <Loader text="로그인 중입니다.." size={16} />

--- a/FE/src/pages/IssuePage/Detail/Main/index.tsx
+++ b/FE/src/pages/IssuePage/Detail/Main/index.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 import * as S from './style';
 
@@ -6,44 +8,68 @@ import { Button, TextButton } from '@components/Button';
 import I from '@components/Icons';
 import { Textarea, Input } from '@components/Input';
 import UserAvatar from '@components/UserAvatar';
+import { useInput } from '@hooks/useInput';
+import { usePostIssue } from '@hooks/usePostIssue';
+import { userState } from '@recoil/atoms/user';
+
+const issuePagePath = '/issue';
 
 // ADD ISSUE
 export const NewMain = () => {
-  // TODO: 커스텀 훅으로 바꾸기
-  const [value, setValue] = useState('');
-  const [value2, setValue2] = useState('');
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    setValue(e.target.value);
-  const onChange2 = (e: React.ChangeEvent<HTMLInputElement>) =>
-    setValue2(e.target.value);
+  const navigate = useNavigate();
+  const { mutate, isLoading } = usePostIssue();
+  const user = useRecoilValue(userState);
+
+  const title = useInput();
+  const comment = useInput();
+
+  const handleClickCancelButton = () => {
+    navigate(issuePagePath);
+  };
+
+  const handleClickSubmitButton = (e: React.FormEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (title.value.trim().length === 0) {
+      return;
+    }
+
+    mutate({
+      title: title.value,
+      content: comment.value,
+    });
+  };
+
   return (
-    <S.DetailMainLayer as="form">
+    <S.DetailMainLayer as="form" onSubmit={handleClickSubmitButton}>
       <S.Inputs>
         <S.UserAvatar>
-          <UserAvatar
-            src="https://www.stignatius.co.uk/wp-content/uploads/2020/10/default-user-icon.jpg"
-            size="lg"
-          />
+          <UserAvatar src={user!.profileImageUrl} size="lg" />
         </S.UserAvatar>
-        <Input
-          width="100%"
-          placeholder="제목"
-          size="md"
-          value={value2}
-          onChange={onChange2}
-        />
-        <Textarea width="100%" value={value} onChange={onChange} />
+        <Input width="100%" placeholder="제목" size="md" {...title} />
+        <Textarea width="100%" {...comment} />
       </S.Inputs>
-      <S.SideBar>사이드바</S.SideBar>
       <S.Buttons>
-        <TextButton size="md" type="button">
+        <TextButton
+          size="md"
+          type="button"
+          onClick={handleClickCancelButton}
+          disabled={isLoading}
+        >
           <I.XMark />
           작성 취소
         </TextButton>
-        <Button size="md" type="button">
+
+        <Button
+          size="md"
+          type="button"
+          onClick={handleClickSubmitButton}
+          disabled={!title.value.trim().length}
+          loading={isLoading}
+        >
           완료
         </Button>
       </S.Buttons>
+      <S.SideBar>사이드바</S.SideBar>
     </S.DetailMainLayer>
   );
 };

--- a/FE/src/pages/IssuePage/Detail/Main/style.ts
+++ b/FE/src/pages/IssuePage/Detail/Main/style.ts
@@ -19,8 +19,8 @@ export const IssueComments = styled.main`
 
 export const Inputs = styled(IssueComments)`
   display: grid;
-  grid-template-columns: 44px 55rem;
-  grid-template-rows: 2;
+  grid-template-columns: 2.75rem 55rem;
+  grid-template-rows: repeat(2);
   gap: 16px;
 `;
 
@@ -38,7 +38,7 @@ export const SideBar = styled.aside`
 `;
 
 export const Buttons = styled.footer`
-  ${flexbox({ jc: 'flex-end' })};
+  ${flexbox({ jc: 'flex-end', ai: 'center' })};
   gap: 2rem;
   grid-column-start: 1;
   grid-column-end: 3;

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
-import { useQuery } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 import * as S from './style';
 
@@ -18,6 +18,7 @@ const getLabels = async () => {
 };
 
 export default function LabelPage() {
+  const queryClient = useQueryClient();
   const { data, status } = useQuery('labelData', getLabels);
   const [openForm, setOpenForm] = useState(false);
   const [editOpenForm, setEditOpenForm] = useState<{ [id: number]: boolean }>(
@@ -43,9 +44,20 @@ export default function LabelPage() {
     setModalVisible(false);
   };
 
+  const deleteLabel = useMutation(
+    (id: number) =>
+      fetch(`/issue/label/${id}`, {
+        method: 'DELETE',
+      }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('labelData');
+      },
+    },
+  );
+
   const handleLabelDeleteSubmit = () => {
-    // TODO delete api request
-    console.log(deleteId);
+    deleteLabel.mutate(deleteId);
     setModalVisible(false);
   };
 

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 
@@ -7,6 +8,7 @@ import { Button } from '@components/Button';
 import I from '@components/Icons';
 import { Label } from '@components/Label';
 import Form from '@components/Label/Form';
+import Modal from '@components/Modal';
 import TabList from '@components/TabList';
 import { ILabelTypes } from '@recoil/atoms/label';
 
@@ -18,6 +20,45 @@ const getLabels = async () => {
 export default function LabelPage() {
   const { data, status } = useQuery('labelData', getLabels);
   const [openForm, setOpenForm] = useState(false);
+  const [editOpenForm, setEditOpenForm] = useState<{ [id: number]: boolean }>(
+    {},
+  );
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [deleteId, setDeleteId] = useState(0);
+
+  const handleLabelEditClick = (id: number) => {
+    setEditOpenForm(prevEditFormState => ({
+      ...prevEditFormState,
+      [id]: true,
+    }));
+  };
+
+  const handleLabelDeleteClick = (id: number) => {
+    setModalVisible(true);
+    setDeleteId(id);
+  };
+
+  const handleLabelDeleteCancel = () => {
+    setModalVisible(false);
+  };
+
+  const handleLabelDeleteSubmit = () => {
+    // TODO delete api request
+    console.log(deleteId);
+    setModalVisible(false);
+  };
+
+  const handleCloseForm = (id?: number) => {
+    if (id) {
+      setEditOpenForm(prevEditFormState => ({
+        ...prevEditFormState,
+        [id]: false,
+      }));
+    } else {
+      setOpenForm(false);
+    }
+  };
 
   return (
     <S.LabelPageLayer>
@@ -35,32 +76,87 @@ export default function LabelPage() {
           </Button>
         )}
       </S.Header>
-      {openForm && <Form title="새로운 레이블 추가" />}
+      {openForm && (
+        <Form
+          title="새로운 레이블 추가"
+          onEdit={false}
+          handleCloseForm={handleCloseForm}
+        />
+      )}
       <S.Main>
         <S.LabelCount>
           {status === 'success' ? data.length : 0}개의 레이블
         </S.LabelCount>
         {status === 'success' &&
-          data.map((label: ILabelTypes) => (
-            <S.LabelItemWrapper key={label.id}>
-              <S.LabelLeft>
-                <Label bgColor={label.color} darkText={label.darkText}>
-                  {label.name}
-                </Label>
-                <S.LabelTitle>Label Title</S.LabelTitle>
-              </S.LabelLeft>
-              <S.LabelRight>
-                <S.EditBox>
-                  <I.Edit />
-                  <span>편집</span>
-                </S.EditBox>
-                <S.TrashBox>
-                  <I.Trash />
-                  <span>삭제</span>
-                </S.TrashBox>
-              </S.LabelRight>
-            </S.LabelItemWrapper>
-          ))}
+          data.map((label: ILabelTypes) =>
+            editOpenForm[label.id] ? (
+              <Form
+                key={`EditLabelForm-${label.title}`}
+                title="레이블 편집"
+                onEdit
+                labelData={label}
+                handleCloseForm={id => handleCloseForm(id)}
+              />
+            ) : (
+              <S.LabelItemWrapper key={label.id}>
+                <S.LabelLeft>
+                  <Label
+                    bgColor={label.backgroundColor}
+                    darkText={label.textColor === 'BLACK'}
+                  >
+                    {label.title}
+                  </Label>
+                  <S.LabelTitle>Label Title</S.LabelTitle>
+                </S.LabelLeft>
+                <S.LabelRight>
+                  <button
+                    type="button"
+                    onClick={() => handleLabelEditClick(label.id)}
+                  >
+                    <S.EditBox>
+                      <I.Edit />
+                      <span>편집</span>
+                    </S.EditBox>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleLabelDeleteClick(label.id)}
+                  >
+                    <S.TrashBox>
+                      <I.Trash />
+                      <span>삭제</span>
+                    </S.TrashBox>
+                  </button>
+                </S.LabelRight>
+              </S.LabelItemWrapper>
+            ),
+          )}
+        {modalVisible && (
+          <Modal>
+            <header
+              css={css`
+                margin-bottom: 2rem;
+              `}
+            >
+              해당 레이블을 정말 삭제하시겠습니까?
+            </header>
+            <div>
+              <Button
+                outlined
+                type="button"
+                onClick={handleLabelDeleteCancel}
+                css={css`
+                  margin-right: 1rem;
+                `}
+              >
+                닫기
+              </Button>
+              <Button type="button" onClick={handleLabelDeleteSubmit}>
+                확인
+              </Button>
+            </div>
+          </Modal>
+        )}
       </S.Main>
     </S.LabelPageLayer>
   );

--- a/FE/src/pages/LabelPage/style.ts
+++ b/FE/src/pages/LabelPage/style.ts
@@ -47,6 +47,9 @@ export const LabelLeft = styled.div`
 export const LabelRight = styled.div`
   ${flexbox};
   gap: 1.7rem;
+  button {
+    background-color: transparent;
+  }
 `;
 
 export const LabelItemWrapper = styled.div`
@@ -65,4 +68,6 @@ export const Main = styled.div`
   overflow: hidden;
 `;
 
-export const LabelPageLayer = styled.div``;
+export const LabelPageLayer = styled.div`
+  margin-bottom: 6rem;
+`;

--- a/FE/src/pages/Verification/index.tsx
+++ b/FE/src/pages/Verification/index.tsx
@@ -1,8 +1,11 @@
+import { css } from '@emotion/react';
 import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import { Loader } from '@components/Indicator';
 import { useIsLoggedIn } from '@hooks/useIsLoggedIn';
 import { useSilentRefresh } from '@hooks/useLogin';
+import { alignPosXY } from '@styles/mixin';
 
 function Verification() {
   const isLoggedIn = useIsLoggedIn();
@@ -15,7 +18,17 @@ function Verification() {
 
     silentRefresh('/error');
   }, [isLoggedIn]);
-  return <Outlet />;
+  return !isLoggedIn ? (
+    <div
+      css={css`
+        ${alignPosXY('fixed')}
+      `}
+    >
+      <Loader size={16} text="로딩중입니다..." />{' '}
+    </div>
+  ) : (
+    <Outlet />
+  );
 }
 
 export default Verification;

--- a/FE/src/recoil/atoms/label.ts
+++ b/FE/src/recoil/atoms/label.ts
@@ -2,9 +2,10 @@ import { atom } from 'recoil';
 
 export interface ILabelTypes {
   id: number;
-  color: string;
-  name: string;
-  darkText?: boolean;
+  backgroundColor: string;
+  title: string;
+  description?: string;
+  textColor: string;
 }
 
 export const labelState = atom<{ info: ILabelTypes[] }>({
@@ -13,13 +14,15 @@ export const labelState = atom<{ info: ILabelTypes[] }>({
     info: [
       {
         id: 1,
-        color: '#000000',
-        name: 'colaLabel',
+        backgroundColor: '#000000',
+        title: 'colaLabel',
+        textColor: 'BLACK',
       },
       {
         id: 2,
-        color: '#0025E7',
-        name: 'muffinLabel',
+        backgroundColor: '#0025E7',
+        title: 'muffinLabel',
+        textColor: 'BLACK',
       },
     ],
   },

--- a/FE/src/recoil/atoms/milestone.ts
+++ b/FE/src/recoil/atoms/milestone.ts
@@ -11,11 +11,11 @@ export const mileStoneState = atom<{ info: IMileStoneTypes[] }>({
     info: [
       {
         id: 1,
-        name: 'muffinMileStone',
+        name: 'muffinMileStone한글네글',
       },
       {
         id: 2,
-        name: 'colaMileStone',
+        name: 'colaMileStone한글셋',
       },
     ],
   },

--- a/FE/src/styles/GlobalStyle.tsx
+++ b/FE/src/styles/GlobalStyle.tsx
@@ -147,6 +147,7 @@ const style = css`
 
   button {
     cursor: pointer;
+    background-color: transparent;
   }
 `;
 

--- a/FE/src/styles/theme.ts
+++ b/FE/src/styles/theme.ts
@@ -37,6 +37,9 @@ const zIndex = {
     header: 900, // Filter-Bar 영역
     main: 800, // Issue-List 영역
   },
+  sideBar: {
+    popup: 100, // Side-Bar Popup 영역
+  },
 };
 
 const theme = {

--- a/FE/src/type/label.ts
+++ b/FE/src/type/label.ts
@@ -1,0 +1,7 @@
+export interface Label {
+  id: number;
+  backgroundColor: string;
+  title: string;
+  description?: string;
+  textColor: string;
+}

--- a/FE/src/type/milestone.ts
+++ b/FE/src/type/milestone.ts
@@ -1,0 +1,9 @@
+export interface MileStone {
+  id: number;
+  title: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  dueDate?: string;
+  progressRate: number;
+}

--- a/FE/src/utils/Compose.tsx
+++ b/FE/src/utils/Compose.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  components: Array<React.JSXElementConstructor<React.PropsWithChildren<any>>>;
+  children: React.ReactNode;
+}
+
+export default function Compose(props: Props) {
+  const { components = [], children } = props;
+
+  return (
+    <>
+      {components.reduceRight(
+        (acc, Comp) => (
+          <Comp>{acc}</Comp>
+        ),
+        children,
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
안녕하세요 크롱!! Cola, Muffin입니다. 3주차 1번째 PR 보냅니다, 감사합니다~!

지난번에 리뷰해주신, 쿠키가 어차피 전달이 될텐데 HTTP Header에 왜 넣어주는지? 에 대한 부분은 저희도 의아했던 부분이라 백엔드분과 이야기를 나눠보고 있습니다!

## ☑진행상황

데이터는 아직 msw를 사용중이라 서버쪽에서 api가 완성되는대로 데이터를 실제 서버와 연동되도록 수정하는게 1순위입니다. 이번주는 크게 레이블 페이지, 이슈 생성 페이지, 이슈 메인 페이지 기능을 작업하였습니다.

api가 완성되지 않아, 데모페이지를 사용할 수 없는만큼 글에 `gif`를 최대한 많이 넣었습니다!

### ✅ 레이블 페이지 작업

지난주에 UI 작업을 마무리하고 이번주에는 Create, update, delete 관련 기능을 작업했습니다. 추가폼과 수정폼을 같은 Form 컴포넌트에서 제어하려다보니 Form 컴포넌트 자체가 커져서 어떻게 Form 컴포넌트 내부를 다시 나눌지 고민중입니다. ( 레이아웃을 담당하는 Form ⇒ 기능을 담당하는 AddForm, EditForm 컴포넌트로 나눠서 할까 고민중입니다. )

Form 컴포넌트 내에서 수정 Form 일때 이전 값들(title, description, backgroundColor,textColor) 중 하나라도 변경되면 버튼 disable를 다루기 위해 아래와 같이 두 가지 상태를 두었습니다.

openFormValue : 레이블 Form안의 데이터들을 객체로 관리하는 상태

initFormValue: 수정폼에서 이전에 수정된 내용을 계속 체킹하기 위해서 초기의 Form값만 들고 있는 상태

![LabelPage](https://user-images.githubusercontent.com/79135734/176383197-9b2912d2-0bf5-4593-aafa-8431509093ca.gif)

### ✅ 이슈 생성 페이지
 
![New Issue](https://user-images.githubusercontent.com/79135734/176383304-48f26690-56d1-4806-a683-a54045e44d0b.gif)

- 제목이 입력되지 않으면 확인버튼을 `Disabled`시켰지만, 사용자가 개발자도구에서 강제로 `Disabled`를 지울 수 있어서, 제출할 때 한번 더 확인하여 막도록 했습니다.
- `POST`요청을 여러번 보낼 수 없도록 하기 위해, 요청이 가는 순간부터 도착할 때 까지는 완료버튼을 없앴습니다. 버튼은 최소Width가 정해져 있는 반면, 작성 취소버튼은 단순 텍스트요소라서, 글자 길이에 따라 Width가 정해지기 때문에 Loader를 적용하면 위치가 이상해져서.. 일단 요청을 보낼 때는 Disabled로 바꿔 주었습니다.
- 요청 성공시 Detail페이지로 이동하는데, Detail Page 작업은 아직 안되어있는 상태입니다.

### ✅ 사이드바 패널

![SideBar](https://user-images.githubusercontent.com/79135734/176383373-ae6d74f0-bbb8-41b3-ab14-ca8abb34c556.gif)

유저, 레이블, 마일스톤이 많아질수록 선택 박스가 커지는것을 방지하기 위해 스크롤을 주었습니다.

![SideBar-scroll](https://user-images.githubusercontent.com/79135734/176383397-6f82575f-0a74-422d-83b4-e54f58d3abdc.PNG)


### ✅ 이슈 메인페이지 작업 ( useDebounce, Search Input, CheckBox )

이슈 상단 검색 인풋의 문자 글자수가 60자이상일 경우 api 요청이 되지 않도록 하기 위해서 만들게 되었는데, 문자 길이를 계속해서 체킹하는것이 아닌 설정한 시간 안에서 마지막 한 번만 엔터를 누른 시점을 체킹하기 위해 debounce를 적용해보았습니다.

![IssueMain](https://user-images.githubusercontent.com/79135734/176383496-a43eb290-3b75-4fe4-9645-5eba9b4cf712.gif)

---

로그인 이후에 이슈 메인 페이지에 접속했을때 무조건 검색창 인풋에 is:open value가 셋팅되도록 하였습니다.
 
![init IssueMain](https://user-images.githubusercontent.com/79135734/176384516-aab3e5e6-4608-4b0c-ab8f-294091737b0a.gif)

![IssueMainFilter](https://user-images.githubusercontent.com/79135734/176383637-64bbcf1c-e324-4f38-b80f-ceb642730e0b.gif)

이슈 필터 팝업에선 Github Issue 와 동일하게 동작되도록 하였습니다. 

열린 이슈, 닫힌 이슈를 클릭 시 ⇒ useSearch의 init 함수로 초기화하므로 url 뿐만아니라 searchInput 값도 is:open 또는 is:close로만 변경됨

내가 작성한 이슈, 나에게 할당된 이슈, 내가 댓글을 남긴 이슈 클릭 시 ⇒ replace(’me’, 각 항목에대한 값) 함수가 동작하므로 뒤에 동일 key값 체킹하면서 붙여줌

---

## ☑질문
