### PR TITLE
[team-20][FE] Millie & J 3주차 1번째 PR

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,0 +1,46 @@
+name: react workflow
+
+on:
+  push:
+    branches: [dev-FE]
+  pull_request:
+    branches: [dev-FE]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./FE # 기본 워킹 디렉토리 설정
+    steps:
+      - name: Checkout source code.
+        uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 cp --recursive --region ap-northeast-2 dist s3://issue-tracker-fe
+
+      - name: CloudFront Invalidation
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_CLOUDFRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
+
+        run: aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID --paths "/*" --region ap-northeast-2

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -17,6 +17,7 @@
         "react-icons": "^4.4.0",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
+        "recoil": "^0.7.4",
         "styled-components": "^5.3.5"
       },
       "devDependencies": {
@@ -5642,6 +5643,11 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -8333,6 +8339,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/regenerate": {
@@ -14290,6 +14315,11 @@
       "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
       "dev": true
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -16225,6 +16255,14 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "regenerate": {

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -15,6 +15,7 @@
         "react-cookie": "^4.1.1",
         "react-dom": "^18.1.0",
         "react-icons": "^4.4.0",
+        "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
         "styled-components": "^5.3.5"
       },
@@ -3228,8 +3229,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3256,6 +3256,14 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -3356,7 +3364,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3372,6 +3379,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -3737,8 +3759,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -4093,8 +4114,7 @@
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5418,8 +5438,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -5538,7 +5557,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6024,7 +6042,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6033,8 +6050,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
       "version": "8.2.4",
@@ -6537,6 +6553,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6840,6 +6861,15 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6903,6 +6933,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -7026,7 +7061,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7215,6 +7249,14 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -7433,6 +7475,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -7464,7 +7511,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7732,7 +7778,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8194,6 +8239,31 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "peer": true
     },
+    "node_modules/react-query": {
+      "version": "3.39.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
+      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -8379,6 +8449,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -8499,7 +8574,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9461,6 +9535,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9998,8 +10081,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.8.0",
@@ -12401,8 +12483,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -12415,6 +12496,11 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -12504,7 +12590,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -12517,6 +12602,21 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "browserslist": {
@@ -12784,8 +12884,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "confusing-browser-globals": {
       "version": "1.0.11",
@@ -13036,8 +13135,7 @@
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -14047,8 +14145,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -14130,7 +14227,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14484,7 +14580,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -14493,8 +14588,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "8.2.4",
@@ -14839,6 +14933,11 @@
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15071,6 +15170,15 @@
         }
       }
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -15119,6 +15227,11 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "mime": {
       "version": "1.6.0",
@@ -15205,7 +15318,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -15338,6 +15450,14 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -15491,6 +15611,11 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -15516,7 +15641,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -15713,8 +15837,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -16042,6 +16165,16 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "peer": true
     },
+    "react-query": {
+      "version": "3.39.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
+      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -16183,6 +16316,11 @@
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -16274,7 +16412,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -17012,6 +17149,15 @@
         }
       }
     },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -17406,8 +17552,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
       "version": "8.8.0",

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.27.2",
         "moment": "^2.29.3",
         "react": "^18.1.0",
+        "react-cookie": "^4.1.1",
         "react-dom": "^18.1.0",
         "react-icons": "^4.4.0",
         "react-router-dom": "^6.3.0",
@@ -2209,7 +2210,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -2263,8 +2263,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2282,7 +2281,6 @@
       "version": "18.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
       "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2328,8 +2326,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -3990,8 +3987,7 @@
     "node_modules/csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8159,6 +8155,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -9428,6 +9437,28 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/unpipe": {
@@ -11576,7 +11607,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -11630,8 +11660,7 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -11649,7 +11678,6 @@
       "version": "18.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
       "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11695,8 +11723,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -12933,8 +12960,7 @@
     "csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -15985,6 +16011,16 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -16954,6 +16990,27 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
       "dev": true
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "@types/cookie": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+          "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+        },
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/FE/package.json
+++ b/FE/package.json
@@ -27,6 +27,7 @@
     "react-icons": "^4.4.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
+    "recoil": "^0.7.4",
     "styled-components": "^5.3.5"
   },
   "devDependencies": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -22,6 +22,7 @@
     "axios": "^0.27.2",
     "moment": "^2.29.3",
     "react": "^18.1.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.1.0",
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.3.0",

--- a/FE/package.json
+++ b/FE/package.json
@@ -25,6 +25,7 @@
     "react-cookie": "^4.1.1",
     "react-dom": "^18.1.0",
     "react-icons": "^4.4.0",
+    "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
     "styled-components": "^5.3.5"
   },

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { QueryClientProvider, QueryClient } from 'react-query';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
@@ -14,6 +15,8 @@ import GlobalStyle from '@/styles/GlobalStyle';
 import { DARK, LIGHT } from '@/styles/theme';
 import { getDefaultTheme } from '@/utils/mode';
 
+const queryClient = new QueryClient();
+
 const App = () => {
   const [theme, setTheme] = useState(getDefaultTheme());
   const isLight = theme === LIGHT;
@@ -24,22 +27,24 @@ const App = () => {
   };
 
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Router>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Home />} />
-            <Route path="new-issue" element={<NewIssue />} />
-            <Route path="issue/:id" element={<IssueDetail />} />
-          </Route>
-          <Route path="callback" element={<LoginCallback />} />
-          <Route path="login" element={<Login />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Router>
-      <ThemeSwitch switchTheme={switchTheme} isLight={isLight} />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Router>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Home />} />
+              <Route path="new-issue" element={<NewIssue />} />
+              <Route path="issue/:id" element={<IssueDetail />} />
+            </Route>
+            <Route path="callback" element={<LoginCallback />} />
+            <Route path="login" element={<Login />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Router>
+        <ThemeSwitch switchTheme={switchTheme} isLight={isLight} />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -7,6 +7,7 @@ import Layout from '@/layout';
 import Home from '@/pages/Home';
 import IssueDetail from '@/pages/IssueDetail';
 import Login from '@/pages/Login';
+import LoginCallback from '@/pages/LoginCallback';
 import NewIssue from '@/pages/NewIssue';
 import NotFound from '@/pages/NotFound';
 import GlobalStyle from '@/styles/GlobalStyle';
@@ -32,6 +33,7 @@ const App = () => {
             <Route path="new-issue" element={<NewIssue />} />
             <Route path="issue/:id" element={<IssueDetail />} />
           </Route>
+          <Route path="callback" element={<LoginCallback />} />
           <Route path="login" element={<Login />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
 import ThemeSwitch from '@/components/ThemeSwitch';
@@ -30,18 +31,20 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Router>
-          <Routes>
-            <Route path="/" element={<Layout />}>
-              <Route index element={<Home />} />
-              <Route path="new-issue" element={<NewIssue />} />
-              <Route path="issue/:id" element={<IssueDetail />} />
-            </Route>
-            <Route path="callback" element={<LoginCallback />} />
-            <Route path="login" element={<Login />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Router>
+        <RecoilRoot>
+          <Router>
+            <Routes>
+              <Route path="/" element={<Layout />}>
+                <Route index element={<Home />} />
+                <Route path="new-issue" element={<NewIssue />} />
+                <Route path="issue/:id" element={<IssueDetail />} />
+              </Route>
+              <Route path="callback" element={<LoginCallback />} />
+              <Route path="login" element={<Login />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Router>
+        </RecoilRoot>
         <ThemeSwitch switchTheme={switchTheme} isLight={isLight} />
       </ThemeProvider>
     </QueryClientProvider>

--- a/FE/src/components/Comment/index.tsx
+++ b/FE/src/components/Comment/index.tsx
@@ -3,7 +3,7 @@ import UserProfile from '../common/UserProfile';
 import * as S from './style';
 import { CommentProps } from './type';
 
-import { Emoji } from '@/icons/emoji';
+import { Emoji } from '@/icons/Emoji';
 import { getRelativeTime } from '@/utils/issue';
 
 const Comment = ({ issueAuthor, userId, imgUrl, createTime, description }: CommentProps) => {

--- a/FE/src/components/CommentForm/index.tsx
+++ b/FE/src/components/CommentForm/index.tsx
@@ -1,3 +1,5 @@
+import { useRecoilValue } from 'recoil';
+
 import * as S from './style';
 
 import Button from '@/components/common/Button';
@@ -5,12 +7,14 @@ import Input from '@/components/common/Input';
 import TextArea from '@/components/common/TextArea';
 import UserProfile from '@/components/common/UserProfile';
 import SideBar from '@/components/SideBar';
+import { userState } from '@/stores/atoms/user';
 
 type CommentFormProps = {
   newIssue?: boolean;
 };
 
 const CommentForm = ({ newIssue }: CommentFormProps) => {
+  const userData = useRecoilValue(userState);
   const btnStyle = {
     size: newIssue ? 'medium' : 'small',
     text: newIssue ? 'Submit new issue' : 'Comment',
@@ -19,11 +23,7 @@ const CommentForm = ({ newIssue }: CommentFormProps) => {
   return (
     <S.NewIssueForm>
       <S.FlexWrapper>
-        <UserProfile
-          imgUrl="https://avatars.githubusercontent.com/u/85419343?s=80&v=4"
-          userId="jaypeida"
-          size="large"
-        />
+        <UserProfile imgUrl={userData?.profileImageUrl} userId={userData?.name} size="large" />
         <S.CommentWrapper>
           {newIssue && (
             <Input name="title" placeholder="Title" inputStyle="medium" title="Title" type="text" />

--- a/FE/src/components/Header/index.tsx
+++ b/FE/src/components/Header/index.tsx
@@ -1,19 +1,20 @@
+import { useRecoilValue } from 'recoil';
+
 import * as S from './style';
 
 import CustomLink from '@/components/common/CustomLink';
 import UserProfile from '@/components/common/UserProfile';
 import Logo from '@/icons/Logo';
+import { userState } from '@/stores/atoms/user';
 
 const Header = () => {
+  const userData = useRecoilValue(userState);
+
   return (
     <S.HeaderWrapper>
       <S.InnerFlex>
         <CustomLink path="/" component={<Logo />} />
-        <UserProfile
-          imgUrl="https://avatars.githubusercontent.com/u/85419343?s=80&v=4"
-          userId="jaypeida"
-          size="large"
-        />
+        <UserProfile imgUrl={userData?.profileImageUrl} userId={userData?.name} size="large" />
       </S.InnerFlex>
     </S.HeaderWrapper>
   );

--- a/FE/src/components/IssueList/List.tsx
+++ b/FE/src/components/IssueList/List.tsx
@@ -16,8 +16,7 @@ const IssueList = ({ list }: IssueListType) => {
 };
 
 const List = ({ list }: IssueListType) => {
-  const issuesCount = list.length;
-  return issuesCount ? <IssueList list={list} /> : <EmptyList text="Welcome to issues!" />;
+  return list?.length ? <IssueList list={list} /> : <EmptyList text="Welcome to issues!" />;
 };
 
 export default List;

--- a/FE/src/components/common/Loading/index.tsx
+++ b/FE/src/components/common/Loading/index.tsx
@@ -1,0 +1,7 @@
+import * as S from './style';
+
+const Loading = () => {
+  return <S.Loading>Loading...</S.Loading>;
+};
+
+export default Loading;

--- a/FE/src/components/common/Loading/style.ts
+++ b/FE/src/components/common/Loading/style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+// TODO: 임시 스타일. 추후 수정해야합니다.
+const Loading = styled.div`
+  color: red;
+  font-size: 100px;
+`;
+
+export { Loading };

--- a/FE/src/constants/constants.ts
+++ b/FE/src/constants/constants.ts
@@ -1,12 +1,9 @@
-interface IssueStatus {
-  open: 'open';
-  closed: 'closed';
-}
-
-export const ISSUE_STATUS: IssueStatus = {
+export const ISSUE_STATUS = {
   open: 'open',
   closed: 'closed',
-};
+} as const;
+
+export type IssueStatusType = typeof ISSUE_STATUS[keyof typeof ISSUE_STATUS];
 
 export const QUERY_KEY = {
   author: 'author',

--- a/FE/src/constants/login.ts
+++ b/FE/src/constants/login.ts
@@ -1,0 +1,2 @@
+export const LOGIN_URL =
+  'https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&amp;scope=read:user%20user:email';

--- a/FE/src/mocks/utils.ts
+++ b/FE/src/mocks/utils.ts
@@ -1,5 +1,5 @@
-import { IssueItemType, Assignees } from '@/components/IssueList/type';
-import { ISSUE_STATUS, QUERY_KEY } from '@/constants/constants';
+import { Assignees } from '@/components/IssueList/type';
+import { ISSUE_STATUS, QUERY_KEY, IssueStatusType } from '@/constants/constants';
 
 // Reference: thanks to @happyGyu
 
@@ -23,7 +23,7 @@ const filterByQuery = (queryKey: string, queryValue: string | null, originalIssu
   }
 };
 
-const filterByStatus = (target: 'open' | 'closed', originalIssues) => {
+const filterByStatus = (target: IssueStatusType, originalIssues) => {
   const filtered = originalIssues.filter(issue => issue.issueStatus === target);
   const oppositeStatusCount = originalIssues.length - filtered.length;
   return {

--- a/FE/src/pages/Home/index.tsx
+++ b/FE/src/pages/Home/index.tsx
@@ -1,37 +1,27 @@
 import axios from 'axios';
-import { useState, useEffect } from 'react';
+import { useQuery } from 'react-query';
 
+import Loading from '@/components/common/Loading';
 import HomeHeader from '@/components/HomeHeader';
 import IssueList from '@/components/IssueList';
 import { InnerContainer, MainWrapper } from '@/styles/common';
 
+const fetchAPI = () => {
+  return axios.get('/api/issues?issueStatus=open');
+};
+
 const Home = () => {
-  // TODO: issue 상태를 전역으로 놓는다
   // TODO: open/closed 클릭할 때마다 fetch 요청
   // TODO: open 탭에 있을 때 또 open 탭을 클릭 시에는 fetch 요청 X
 
-  const [issues, setIssues] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data: issues, isLoading } = useQuery('issueList', fetchAPI);
 
-  const getIssues = async () => {
-    setIsLoading(true);
-    const response = await axios.get('/api/issues?issueStatus=open');
-
-    if (response.data) {
-      setIssues(response.data.issues);
-    }
-
-    setIsLoading(false);
-  };
-
-  useEffect(() => {
-    getIssues();
-  }, []);
   return (
     <MainWrapper>
       <InnerContainer>
         <HomeHeader />
-        {!isLoading && <IssueList list={issues} />}
+        {isLoading && <Loading />}
+        <IssueList list={issues?.data.issues} />
       </InnerContainer>
     </MainWrapper>
   );

--- a/FE/src/pages/Login/index.tsx
+++ b/FE/src/pages/Login/index.tsx
@@ -2,6 +2,7 @@ import * as S from './style';
 
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
+import { LOGIN_URL } from '@/constants/login';
 import Logo from '@/icons/Logo';
 
 const Login = () => {
@@ -9,7 +10,9 @@ const Login = () => {
     <S.LoginWrapper>
       <Logo />
       <S.LoginBox>
-        <Button btnSize="large" btnColor="black" text="Login with GitHub" />
+        <a href={LOGIN_URL}>
+          <Button btnSize="large" btnColor="black" text="Login with GitHub" changeTag="div" />
+        </a>
         <S.OrDivider>or</S.OrDivider>
         <S.LoginForm>
           <Input type="text" placeholder="User ID" title="User ID" inputStyle="large" />

--- a/FE/src/pages/LoginCallback/index.tsx
+++ b/FE/src/pages/LoginCallback/index.tsx
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { setCookie } from '@/utils/cookie';
+
+const LoginCallback = () => {
+  const AUTH_URI = 'http://3.34.53.135/login/oauth/github/callback';
+  const navigate = useNavigate();
+
+  const onLogin = async () => {
+    const authorizationCode = window.location.search;
+
+    try {
+      // 1) authorization code를 취득하여 get 요청 후 access & refresh token을 얻어옴
+      const response = await axios.get(`${AUTH_URI}${authorizationCode}`);
+      const data = await response.data;
+      const { accessToken, refreshToken } = data;
+
+      // 2) refresh token을 cookie에 저장
+      setCookie('RefreshToken', refreshToken, {
+        path: '/',
+        secure: true,
+      });
+
+      // 3) access token을 default header로 세팅
+      axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+
+      // 4) Home page로 이동
+      navigate('/');
+    } catch (error) {
+      throw new Error(`ERROR: ${error}`);
+    }
+  };
+
+  useEffect(() => {
+    onLogin();
+  }, []);
+
+  return <div>Loading.....</div>;
+};
+
+export default LoginCallback;

--- a/FE/src/stores/atoms/user.ts
+++ b/FE/src/stores/atoms/user.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+
+export const ATOM_USER_KEY = 'userState';
+
+type UserType = {
+  name: string;
+  email: string;
+  profileImageUrl: string;
+};
+
+// TODO: default는 null로 설정, login 성공 시 데이터 다시 설정
+export const userState = atom<UserType>({
+  key: ATOM_USER_KEY,
+  default: {
+    name: 'Millie',
+    email: 'millie@gmail.com',
+    profileImageUrl: 'https://www.industrialempathy.com/img/remote/ZiClJf-1920w.jpg',
+  },
+});

--- a/FE/src/utils/cookie.ts
+++ b/FE/src/utils/cookie.ts
@@ -1,0 +1,16 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+type CookieOptionType = {
+  path: string;
+  secure: boolean;
+};
+
+export const setCookie = (name: string, value: string, option?: CookieOptionType) => {
+  return cookies.set(name, value, { ...option });
+};
+
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};


### PR DESCRIPTION
# 5th PR
안녕하세요! Millie & J 입니다.
이번에는 백엔드와 소통하며 로그인을 구현하는 데 집중하여 기능 구현 내역은 많지 않습니다.
CORS 에러를 수없이 많이 마주쳤습니다 😂


## 1. 구현 내역
- [x] GitHub OAuth Login 구현중 
- [x] Recoil로 userState 관리
- [x] React-query 활용해서 Loading 컴포넌트 구현

## 2. 고민 & 질문
- 정리해 본 OAuth 로그인 흐름은 다음과 같습니다. 
- figma 툴을 활용해 Login Flow를 정리해 보았습니다.([링크](https://www.figma.com/file/6d4TI5eqfjb0uQ8BYaJuD7/%5BMillie-%26-J%5D-Issue-Tracker?node-id=8394%3A5608))

### 1. 기존 방식

1. GitHub 로그인 버튼을 클릭하면 [https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&amp;scope=read:user user:email](https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&amp;scope=read:user%20user:email) 주소로 이동한다. 
2. 사용자가 권한을 승인한다. 
3. Authorization server는 Authorization code를 발급하여 프론트로 보내준다. 
4. 프론트는 Authorization code를 파싱해서 백엔드 서버로 아래와 같은 GET 요청을 보낸다. 
    - [http://3.34.53.135/login/oauth/github/callback](http://3.34.53.135/login/oauth/github/callback)?code={authorizationCode}
5. 백엔드 서버는 Authorization code로 Authorization server에게 토큰을 요청한다.
6. 백엔드 서버는 발급받은 accessToken, refreshToken을 프론트로 보내 준다. 
7. 프론트는 accessToken을 header에 설정하고 refreshToken은 cookie에 저장한다. 
8. 이후 프론트에서 API 요청 시 accessToken과 함께 보낸다. 

### 2. 변경된 방식

1. GitHub 로그인 버튼을 클릭하면 `프론트`는 `백엔드 서버`로 GET 요청을 보낸다. (/login)
2. `백엔드 서버`는 아래 링크로 이동해서, user에게 데이터에 접근하기 위한 권한을 요청한다.
    - [https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&amp;scope=read:user user:email](https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&amp;scope=read:user%20user:email)
3. 사용자가 권한을 승인한다. 
4. `Authorization server`는 Authorization code를 `백엔드 서버`로 보내준다. 
5. 백엔드 서버는 Authorization Server에 토큰을 요청한 후 발급받아 프론트로 accessToken, refreshToken을 보내 준다. 
6. 프론트는 accessToken을 header에 설정하고 refreshToken은 cookie에 저장한다. 
7. 이후 프론트에서 API 요청 시 accessToken과 함께 보낸다. 

### Access Token 만료 시

1. 프론트가 accessToken을 가지고 백엔드 서버로 resource를 요청 시 만약 accessToken이 만료되었다면, 백엔드 서버는 프론트에게 access Token이 만료되었음을 알린다. 
2. 프론트는 쿠키에 저장된 refreshToken을 가져와 header에 넣어 전달한다. 
    - 이때 refreshToken도 만료되었다면 기존 Login은 끊기게 되고 Login 페이지를 보여 준다. 
3. 백엔드 서버는 새로운 accessToken을 발급하여 프론트에게 전달한다.
---
- 기존 방식으로 했을 때는 문제가 없었는데 변경된 방식으로 시도하려고 하니 계속해서 CORS 에러가 나고 있는 상황입니다. 
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/85419343/176391432-763fffc0-3411-4837-9c10-4fad7e621d06.png">


```js
const response = await axios.get('http://3.34.53.135/login', {
        headers: {
          'Access-Control-Allow-Origin': 'localhost:9000',
        },
});
```
- 에러 메시지를 보고 위와 같이 headers를 세팅해 보았지만 에러는 여전히 동일하게 나고 있는 상황입니다. 
- 크롬 확장 프로그램으로 Allow CORS: Access-Control-Allow-Origin이라는 것이 있어서 이것을 활성화시키면 로컬 환경에서 API를 사용할 때 CORS 문제를 해결할 수 있다고 합니다. 
    - 그런데 이것을 사용하면 개발 환경에서는 CORS 에러가 발생하지 않는데 프로덕션 환경에서는 CORS 에러가 발생할 수도 있는 것은 아닌지 궁금해졌습니다. CORS 에러를 근본적으로 해결하는 방법은 아닌 것 같기도 하고요. 



## 3. 이후 계획

- [ ] mock server 추가(POST)
- [ ] Recoil로 전역 상태 관리하여 Dropdown 하나만 열리도록 구현