### PR TITLE
[team-20][BE][검봉 & 타니] IssueTracker 3주차 첫 번째 PR

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -6,13 +6,18 @@ on:
   pull_request:
     branches: [ team20-deploy ]
 
-jobs: # Job 설정
-  build: # Job ID
-    name: hello github action         # Job 이름
-    runs-on: ubuntu-20.04             # Job 가상환경 인스턴스
-    steps: # Steps
-      - name: checkout source code    # Step 이름
-        uses: actions/checkout@v2 # Uses를 통한 외부 설정 가져오기: 자신의 레포지토리 소스 받아오기
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./FE # 기본 워킹 디렉토리 설정
+    steps:
+      - name: Checkout source code.
+        uses: actions/checkout@v2
 
-      - name: echo Hello              # Step 이름
-        run: echo "Hello"
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,0 +1,18 @@
+name: react workflow
+
+on:
+  push:
+    branches: [ team20-deploy ]
+  pull_request:
+    branches: [ team20-deploy ]
+
+jobs: # Job 설정
+  build: # Job ID
+    name: hello github action         # Job 이름
+    runs-on: ubuntu-20.04             # Job 가상환경 인스턴스
+    steps: # Steps
+      - name: checkout source code    # Step 이름
+        uses: actions/checkout@v2 # Uses를 통한 외부 설정 가져오기: 자신의 레포지토리 소스 받아오기
+
+      - name: echo Hello              # Step 이름
+        run: echo "Hello"

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout source code.
         uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
       - name: Install Dependencies
         run: npm install
 

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 cp --recursive --region ap-northeast-2 dist s3://issue-tracker-fe

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -36,3 +36,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: aws s3 cp --recursive --region ap-northeast-2 dist s3://issue-tracker-fe
+
+      - name: CloudFront Invalidation
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_CLOUDFRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
+
+        run: aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID --paths "/*" --region ap-northeast-2

--- a/BE/README.md
+++ b/BE/README.md
@@ -1,9 +1,9 @@
 # BE 구성원
 
 - [@타니](https://github.com/juni8453)
-- [@검봉](https://github.com/geombong) 
+- [@검봉](https://github.com/geombong)
 
-# DB 요구사항 
+# DB 요구사항
 
 # ERD
 
@@ -19,24 +19,29 @@
 - 회원가입 API
 
 ### 아이디/비번 로그인 API
+
 #### 로그인 시 Client -> Server Request
+
 > POST `/signin`
 
 ```json
 {
-  "userId": "작성자 아이디", 
-  "password": "1234" 
+  "userId": "작성자 아이디",
+  "password": "1234"
 }
 ```
+
 ### 회원가입 API
+
 #### 회원가입 시 Client -> Server Request
+
 > POST `/signup`
 
 ```json
 {
-  "userId": "작성자 아이디", 
-  "password": "1234", 
-  "email": "TestID@gmail.com" 
+  "userId": "작성자 아이디",
+  "password": "1234",
+  "email": "TestID@gmail.com"
 }
 ```
 
@@ -52,78 +57,91 @@
 - 닫힌 이슈 리스트 API
 
 ### 모든 이슈 리스트 API
+
 #### 모든 이슈 리스트 확인 시 Server -> Client Response
+
 > GET `/issues`
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀", 
-    "issueWriter": "작성자 아이디", 
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss", 
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지", 
-    "issueStatus": "open" 
-  },
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    },
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
+
 
 /*
 List 형태로 각 이슈가 담긴다.
-모든 이슈가 보이기 때문에 Open, Close 이슈 모두가 담겨야 한다. 
+모든 이슈가 보이기 때문에 Open, closed 이슈 모두가 담겨야 한다. 
 각 이슈 객체는 댓글을 남긴 사용자들의 리스트를 가지고 있다.
 댓글을 있을 수도 있고, 없을 수도 있다.
 만약 댓글이 없다면 빈 리스트가 Response 된다.
@@ -131,119 +149,141 @@ List 형태로 각 이슈가 담긴다.
 ```
 
 ### 열린 이슈 리스트 API(default)
+
 #### 열린 이슈 리스트 확인 시 Server -> Client Response
+
 > GET `/issues/{status}`
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  },
-  {
-    "id": 3,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    },
+    {
+      "id": 3,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
 
 /*
-1 번, 3 번 이슈는 Open 상태, 2 번 이슈는 Close 상태이기 때문에 
+1 번, 3 번 이슈는 Open 상태, 2 번 이슈는 closed 상태이기 때문에 
 1 번, 3 번 이슈만 리스트에 담겨 Response 된다.
 */
 ```
 
 ### 닫힌 이슈 리스트 API
+
 #### 닫힌 이슈 리스트 확인 시 Server -> Client Response
+
 > GET `/issues/{status}`
 
 ```json
-[
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
 
 /*
 1,2,3 중 닫힌 이슈는 2번이기 때문에 현재 2번만 리스트에 담긴 모습
@@ -270,338 +310,403 @@ List 형태로 각 이슈가 담긴다.
 - 내가 댓글을 남긴 이슈 API
 
 ### 내가 작성한 이슈 API
+
 #### 자신이 작성한 이슈 중 닫힌 이슈일 때 Server -> Client Response 여기서 자신이라 함은 작성자 아이디 를 뜻한다.
-> GET `/issues/created_by?status=close&id=myID`
+
+> GET `/issues/created_by?status=closed&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-] 
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
 ```
 
 #### 자신이 작성한 이슈 중 열린 이슈일 때 Server -> Client Response
+
 > GET `/issues/created_by?status=open&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  },
-  {
-    "id": 3,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-] 
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "labels": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    },
+    {
+      "id": 3,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
+
 ```
+
 ### 자신에게 할당된 이슈 API
+
 #### 닫힌 이슈 중 자신에게 할당된 이슈일 때, Server -> Client Response
-> GET `/issues/managed_by?status=close&id=myID`
+
+> GET `/issues/managed_by?status=closed&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-] 
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
 ```
 
 #### 열린 이슈 중 자신에게 할당된 이슈일 때, Server -> Client Response
+
 > GET `/issues/managed_by?status=open&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  },
-  {
-    "id": 3,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-] 
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    },
+    {
+      "id": 3,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
 ```
 
 ### 내가 댓글을 남긴 이슈 API
+
 #### 내가 댓글을 남긴 이슈 중 닫힌 이슈일 때 Server -> Client Response
-> GET `/issues/commented_by?status=close&id=myID`
+
+> GET `/issues/commented_by?status=closed&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-] 
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
 ```
 
 #### 내가 댓글을 남긴 이슈 중 열린 이슈일 때 Server -> Client Response
+
 > GET `/issues/commented_by?status=open&id=myID`
 > myID: 현재 로그인 되어있는 계정의 아이디
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  },
-  {
-    "id": 3,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    },
+    {
+      "id": 3,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
 
 ```
 
@@ -612,123 +717,153 @@ List 형태로 각 이슈가 담긴다.
 <summary>📌이슈 검색 API</summary>
 
 ## 이슈 검색 필요 API
+
 - 제목 검색 API (클릭이 아닌 직접 제목을 검색해서 필터링 하는 것, 제목을 이슈1 이라고 검색했다고 가정한다.)
 
 ### 제목 검색 API
+
 #### 이슈 제목으로 검색 시 Server -> Client Response
+
 > GET `/issues?title=이슈타이틀`
 
 ```json
-[
-  {
-    "id": 1,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 1,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
 ```
+
 #### 닫힌 이슈 제목으로 검색 시 Server -> Client Response
-> GET `/issues?title=이슈타이틀&status=close`
+
+> GET `/issues?title=이슈타이틀&status=closed`
 
 ```json
-[
-  {
-    "id": 2,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "close"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 2,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "closed"
+    }
+  ]
+}
 ```
 
 #### 열린 이슈 제목으로 검색 시 Server -> Client Response
+
 > GET `/issues?title=이슈타이틀&status=open`
 
 ```json
-[
-  {
-    "id": 3,
-    "issueTitle": "이슈 타이틀",
-    "issueWriter": "작성자 아이디",
-    "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-    "labels": [
-      {
-        "id" : 1,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      },
-      {
-        "id" : 2,
-        "title" : "레이블 이름",
-        "backgroundColor": "배경색"
-      }
-    ],
-    "mileStoneTitle": "마일스톤 이름",
-    "assignees" : [
-      {
-        "id" : 1,
-        "image" : "담당자 프로필 이미지"
-      },
-      {
-        "id" : 2,
-        "image" : "담당자 프로필 이미지"
-      }
-    ],
-    "issueWriterImage": "이슈 작성자 프로필 이미지",
-    "issueStatus": "open"
-  }
-]
+{
+  "openIssueCount": "열린 이슈 개수",
+  "closedIssueCount": "닫힌 이슈 개수",
+  "labelCount": "레이블 개수",
+  "milleStoneCount": "마일스톤 개수",
+  "issues": [
+    {
+      "id": 3,
+      "title": "이슈 타이틀",
+      "author": "작성자 아이디",
+      "createdAt": "yyyy-mm-dd HH:MM:ss",
+      "labels": [
+        {
+          "id": 1,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        },
+        {
+          "id": 2,
+          "title": "레이블 이름",
+          "backgroundColor": "배경색",
+          "textColor" : "글자색"
+        }
+      ],
+      "mileStoneTitle": "마일스톤 이름",
+      "assignees": [
+        {
+          "id": 1,
+          "image": "담당자 프로필 이미지"
+        },
+        {
+          "id": 2,
+          "image": "담당자 프로필 이미지"
+        }
+      ],
+      "image": "이슈 작성자 프로필 이미지",
+      "status": "open"
+    }
+  ]
+}
 ```
 
 </details>
@@ -741,29 +876,41 @@ List 형태로 각 이슈가 담긴다.
 - 담당자로 조회 API
 
 1. 닫힌 이슈 API
-> GET `/issues?menager=담담자아이디&status=close`
+
+> GET `/issues?menager=담담자아이디&status=closed`
+
 2. 열린 이슈 API
+
 > GET `/issues?menager=담담자아이디&status=open`
 
 - 레이블로 조회 API
 
 1. 닫힌 이슈 API
-> GET `/issues?label=레이블이름&status=close`
+
+> GET `/issues?label=레이블이름&status=closed`
+
 2. 열린 이슈 API
+
 > GET `/issues?label=레이블이름&status=open`
 
 - 마일스톤으로 조회 API
 
 1. 닫힌 이슈 API
-> GET `/issues?millstone=마일스톤이름&status=close`
+
+> GET `/issues?millstone=마일스톤이름&status=closed`
+
 2. 열린 이슈 API
+
 > GET `/issues?millstone=마일스톤이름&status=open`
 
 - 작성자로 조회 API
 
 1. 닫힌 이슈 API
-> GET `/issues?writer=작성자이름&status=close`
+
+> GET `/issues?writer=작성자이름&status=closed`
+
 2. 열린 이슈 API
+
 > GET `/issues?writer=작성자이름&status=open`
 
 </details>
@@ -772,12 +919,16 @@ List 형태로 각 이슈가 담긴다.
 <summary>📌이슈 탭 API</summary>
 
 ## 이슈 탭 필요 API
+
 - 레이블 목록 API
+
 > GET `/labels`
+
 - 마일스톤 목록 API
+
 > GET `/milestones`
- 
->Server -> Client 로 Response 하는 JSON 데이터는 위와 동일하다.
+
+> Server -> Client 로 Response 하는 JSON 데이터는 위와 동일하다.
 
 </details>
 
@@ -790,14 +941,16 @@ List 형태로 각 이슈가 담긴다.
 - 다중선택 이슈 상태 수정 API
 
 ### 단일선택 이슈 상태 수정 API
+
 #### 하나의 이슈 상태를 수정할 때 Client -> Server Request
+
 > PATCH `/issues/{id}/{status}
-> 이슈의 상태는 현재 상태의 반대를 요청한다. 예를 들어 `open`인 이슈는 `close`를 보내고, `close`이슈는 `open`을 보낸다.
+> 이슈의 상태는 현재 상태의 반대를 요청한다. 예를 들어 `open`인 이슈는 `closed`를 보내고, `closed`이슈는 `open`을 보낸다.
 
 ```json
 {
-  "id": "1", 
-  "requestIssueStatus": "close" 
+  "id": "1",
+  "status": "closed"
 }
 
 /*
@@ -806,33 +959,34 @@ List 형태로 각 이슈가 담긴다.
 ```
 
 ### 다중선택 이슈 상태 수정 API
+
 #### 여러 개의 이슈 상태를 수정할 때 Client -> Server Request
+
 > PATCH `/issues/{issueId}/{requestIssueStatus}`
-> 이슈의 상태는 현재 상태의 반대를 요청한다. 예를 들어 `open`인 이슈는 `close`를 보내고, `close`이슈는 `open`을 보낸다.
+> 이슈의 상태는 현재 상태의 반대를 요청한다. 예를 들어 `open`인 이슈는 `closed`를 보내고, `closed`이슈는 `open`을 보낸다.
 > 예시: `/issues/1,2,3/open`
 
 ```json
 {
-  "issues" : 
-  [
+  "issues": [
     {
-      "id": "1", 
-      "requestIssueStatus": "open" 
+      "id": "1",
+      "status": "open"
     },
     {
-      "id": "2", 
-      "requestIssueStatus": "open" 
+      "id": "2",
+      "status": "open"
     },
     {
-      "id": "3", 
-      "requestIssueStatus": "open" 
+      "id": "3",
+      "status": "open"
     }
   ]
 }
 
 /*
 리스트 형태로 선택한 이슈의 번호와 원하는 상태를 Request 한다.
-현재 1,3 번 이슈는 open 상태라 close를 Request 한다.
+현재 1,3 번 이슈는 open 상태라 closed를 Request 한다.
 */
 ```
 
@@ -842,41 +996,44 @@ List 형태로 각 이슈가 담긴다.
 <summary>📌새로운 이슈 작성 API</summary>
 
 ## 새로운 이슈 작성 필요 API
+
 - 이슈 작성 API
 
 ### 작성 API
+
 #### 이슈 작성 시 Client -> Server Request
+
 > POST `/issues/write`
 
 ```json
 {
-  "id" : 1,
-  "issueTitle": "이슈 제목", 
+  "id": 1,
+  "title": "이슈 제목",
   "issueContent": "이슈 내용",
-  "issueCreateTime": "yyyy-mm-dd HH:MM:ss",
-  "issueWriter": "작성자 아이디",
+  "createdAt": "yyyy-mm-dd HH:MM:ss",
+  "author": "작성자 아이디",
   "files": [
     {
       //"파일과 관련된 Key, Value"
     }
   ],
-  "assignees" : [
+  "assignees": [
     {
-      "id" : 1
+      "id": 1
     },
     {
-      "id" : 2
+      "id": 2
     }
   ],
-  "labels" : [
+  "labels": [
     {
-      "id" : 1
+      "id": 1
     },
     {
-      "id" : 2
+      "id": 2
     }
   ],
-  "mileStone" : 1
+  "mileStoneId": 1
 }
 ```
 
@@ -886,93 +1043,98 @@ List 형태로 각 이슈가 담긴다.
 <summary>📌이슈 상세 조회 API</summary>
 
 ## 이슈 상세 조회 필요 API
+
 - 이슈 상세 페이지 API
 - 제목편집 API
-- 코멘트 목록 API
 - 코멘트 작성 API
 - 코멘트 편집 API
 
 ### 이슈 상세 페이지 API
+
 #### 이슈 상세 페이지 접속 시, Server -> Client Response
+
 > GET `/issues/{id}`
 
 ```json
 {
   "id": 1,
-  "issueTitle": "이슈 타이틀",
-  "issueStatus": "open",
-  "issueCreateTime": "yyyy-MM-dd HH:mm:ss",
+  "title": "이슈 타이틀",
+  "status": "open",
+  "author": "작성자 이름",
+  "createdAt": "yyyy-MM-dd HH:mm:ss",
   "commentCount": 1,
-  "assignees": [
+  "comments" : [
     {
       "id" : 1,
-      "name": "담당자 이름",
-      "image": "담당자 사진"
+      "author" : "작성자 이름",
+      "image" : "작성자 이미지",
+      "content" : "설명",
+      "createdAt": "yyyy-MM-dd HH:mm:ss"
     },
     {
       "id" : 2,
-      "name": "담당자 이름",
+      "author" : "작성자 이름",
+      "image" : "작성자 이미지",
+      "content" : "설명",
+      "createdAt": "yyyy-MM-dd HH:mm:ss"
+    }
+  ],
+  "assignees": [
+    {
+      "id": 1,
+      "title": "담당자 이름",
+      "image": "담당자 사진"
+    },
+    {
+      "id": 2,
+      "title": "담당자 이름",
       "image": "담당자 사진"
     }
   ],
   "labels": [
     {
-      "id" : 1,
-      "name": "레이블 이름"
+      "id": 1,
+      "title": "레이블 이름"
     },
     {
-      "id" : 2,
-      "name": "레이블 이름"
+      "id": 2,
+      "title": "레이블 이름"
     }
   ],
-  "mileStoneTitle" : "마일스톤 이름",
-  "mileStoneDescription" : "마일스톤 설명"
+  "mileStoneTitle": "마일스톤 이름",
+  "mileStoneDescription": "마일스톤 설명"
 }
 
 /*
 assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 */
 ```
+
 ### 제목편집 API
+
 #### 제목 편집 시 Client -> Server Request
+
 > PATCH `/issues/{id}`
- 
+
 ```json
 {
   "id": 1,
-  "issueTitle": "변경할 제목"
+  "title": "변경할 제목"
 }
 ```
 
-### 코멘트 목록 API
-#### 코멘트 목록 조회 시 Server -> Client Response
-> GET `/issues/{id}/comments`
-```json
-[
-  {
-    "id" : 1,
-    "commentWriter" : "작성자 아이디",
-    "commentContent" : "코멘트 내용",
-    "commentCreateTime" : "yyyy-mm-dd HH:MM:ss"
-  },
-  {
-    "id" : 2,
-    "commentWriter" : "작성자 아이디",
-    "commentContent" : "코멘트 내용",
-    "commentCreateTime" : "yyyy-mm-dd HH:MM:ss"
-  }
-]
-```
-
 ### 코멘트 작성 API
+
 #### 코멘트 작성 시 Client -> Server Request
+
 > POST `/issues/{id}/comments`
+
 ```json
 [
   {
-    "commentWriter" : "작성자 아이디",
-    "commentContent" : "코멘트 내용",
-    "commentWriteDate" : "코멘트 작성 날짜",
+    "author": "작성자 아이디",
+    "content": "코멘트 내용",
+    "createAt": "yyyy-mm-dd HH:MM:ss",
     "files": [
       {
         //"파일과 관련된 Key, Value"
@@ -983,14 +1145,17 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 ```
 
 ### 코멘트 편집 API
+
 #### 코멘트 편집 시 Client -> Server Request
+
 > PATCH `/issues/{id}/comments`
+
 ```json
 [
   {
-    "commentWriter" : "작성자 아이디",
-    "commentContent" : "코멘트 내용",
-    "commentWriteDate" : "코멘트 작성 날짜",
+    "author": "작성자 아이디",
+    "content": "코멘트 내용",
+    "createAt": "yyyy-mm-dd HH:MM:ss",
     "files": [
       {
         //"파일과 관련된 Key, Value"
@@ -1006,36 +1171,38 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 <summary>📌레이블 API</summary>
 
 ## 레이블 필요 API
+
 - 레이블 목록 조회 API
 - 레이블 추가 API
 - 레이블 편집 API
 - 레이블 삭제 API
 
 ### 레이블 목록 조회 API
+
 #### 레이블 목록에 접속했을 때, Server -> Client Response
+
 > GET `/labels`
 
 ```json
 {
   "labelCount": 3,
-  "labels" : 
-  [
+  "labels": [
     {
-      "id" : 1,
-      "title": "레이블 제목", 
-      "description": "레이블 설명",
-      "backgroundColor": "배경색", 
-      "textColor": "글자색"
-    },
-    {
-      "id" : 2,
+      "id": 1,
       "title": "레이블 제목",
       "description": "레이블 설명",
       "backgroundColor": "배경색",
       "textColor": "글자색"
     },
     {
-      "id" : 3,
+      "id": 2,
+      "title": "레이블 제목",
+      "description": "레이블 설명",
+      "backgroundColor": "배경색",
+      "textColor": "글자색"
+    },
+    {
+      "id": 3,
       "title": "레이블 제목",
       "description": "레이블 설명",
       "backgroundColor": "배경색",
@@ -1044,36 +1211,46 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
   ]
 }
 ```
+
 ### 레이블 추가 API
+
 #### 레이블 추가 시 Client -> Server Request
+
 > POST `/labels`
 
 ```json
 {
-  "labelTitle": "레이블 제목", 
-  "labelDescription": "레이블 설명",
-  "labelBackgroundColor": "배경색"
+  "title": "레이블 제목",
+  "description": "레이블 설명",
+  "backgroundColor": "배경색",
+  "textColor" : "글자색"
 }
 ```
+
 ### 레이블 편집 API
+
 #### 레이블 편집 시 Client -> Server Request
+
 > PATCH `/labels/{id}`
 
 ```json
 {
-  "labelTitle": "레이블 제목", 
-  "labelDescription": "레이블 설명",
-  "labelBackgroundColor": "배경색"
+  "title": "레이블 제목",
+  "description": "레이블 설명",
+  "backgroundColor": "배경색",
+  "textColor" : "글자색"
 }
 ```
 
 ### 레이블 삭제 API
+
 #### 레이블 삭제 시 Client -> Server Request
+
 > DELETE `/labels/{id}`
 
 ```json
 {
-  "labelId": 1
+  "id": 1
 }
 ```
 
@@ -1090,68 +1267,74 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 - 마일스톤 삭제 API
 
 ### 마일스톤 목록 API
+
 #### 마일스톤 목록 접속 시 Server -> Client Response
+
 > GET `/milestones`
 
 ```json
 {
   "allMileStonesCount": 2,
   "openMileStonesCount": 2,
-  "closeMileStonesCount": 0,
-  
-  "mileStones" :
-  [
+  "closedMileStonesCount": 0,
+  "mileStones": [
     {
-      "id" : 1,
-      "title": "마일스톤 제목", 
-      "endDate": "yyyy-MM-dd HH:mm:ss",
-      "description": "마일스톤 설명",
-      "openIssueCount": 1, 
-      "closeIssueCount": 1 
-    },
-    {
-      "id" : 2,
+      "id": 1,
       "title": "마일스톤 제목",
       "endDate": "yyyy-MM-dd HH:mm:ss",
       "description": "마일스톤 설명",
       "openIssueCount": 1,
-      "closeIssueCount": 1
+      "closedIssueCount": 1
+    },
+    {
+      "id": 2,
+      "title": "마일스톤 제목",
+      "endDate": "yyyy-MM-dd HH:mm:ss",
+      "description": "마일스톤 설명",
+      "openIssueCount": 1,
+      "closedIssueCount": 1
     }
   ]
 }
 ```
 
 ### 마일스톤 추가 API
+
 #### 마일스톤 추가 시 Client -> Server Request
+
 > POST `/milestones`
 
 ```json
 {
-  "mileStoneTitle": "마일스톤 제목", 
-  "mileStoneEndDate": "yyyy-MM-dd HH:mm:ss",
-  "mileStoneDescription": "마일스톤 설명"
+  "title": "마일스톤 제목",
+  "endDate": "yyyy-MM-dd HH:mm:ss",
+  "description": "마일스톤 설명"
 }
 ```
 
 ### 마일스톤 편집 API
+
 #### 마일스톤 편집 시 Client -> Server Request
+
 > PATCH `/milestones/{id}`
 
 ```json
 {
-  "mileStoneTitle": "마일스톤 제목", 
-  "mileStoneEndDate": "yyyy-MM-dd HH:mm:ss",
-  "mileStoneDescription": "마일스톤 설명"
+  "title": "마일스톤 제목",
+  "endDate": "yyyy-MM-dd HH:mm:ss",
+  "description": "마일스톤 설명"
 }
 ```
 
 ### 마일스톤 삭제 API
+
 #### 마일스톤 삭제 시 Client -> Server Request
+
 > DELETE `/milestones/{id}`
 
 ```json
 {
-  "mileStoneId": 1 
+  "id": 1
 }
 ```
 
@@ -1165,22 +1348,23 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 - 담당자 목록 API
 
 ### 담당자 목록 API
+
 #### 담당자 목록 (+ 버튼 클릭) 클릭 시, Sever -> Client Response
+
 > GET `/assignees`
 
 ```json
 {
-  "assignees" : 
-  [
+  "assignees": [
     {
-      "id" : 1,
-      "name": "담당자 이름", 
-      "image": "담당자 이미지" 
+      "id": 1,
+      "title": "담당자 이름",
+      "image": "담당자 프로필 이미지"
     },
     {
-      "id" : 2,
-      "name": "담당자 이름", 
-      "image": "담당자 이미지" 
+      "id": 2,
+      "title": "담당자 이름",
+      "image": "담당자 프로필 이미지"
     }
   ]
 }
@@ -1189,6 +1373,7 @@ assignees, labels, mileStoneName 빈 값이 Response 될 때도 있다.
 담당자가 없는 경우 빈 리스트 [] 를 반환한다.
 */
 ```
+
 </details>
 
 # 인프라

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -2,7 +2,6 @@ package team20.issuetracker.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -11,7 +10,6 @@ import team20.issuetracker.login.interceptor.LoginInterceptor;
 import team20.issuetracker.login.interceptor.TokenInterceptor;
 
 @Configuration
-@EnableWebMvc
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -1,11 +1,11 @@
 package team20.issuetracker.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import lombok.RequiredArgsConstructor;
 import team20.issuetracker.login.interceptor.LoginInterceptor;
 
 @Configuration
@@ -25,6 +25,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:9000");
+                .allowedOrigins("http://localhost:9000/")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -3,12 +3,14 @@ package team20.issuetracker.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import team20.issuetracker.login.interceptor.LoginInterceptor;
 
 @Configuration
+@EnableWebMvc
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
@@ -25,6 +27,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:9000");
+                .allowedOrigins("http://localhost:9000")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -1,24 +1,21 @@
 package team20.issuetracker.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import team20.issuetracker.login.interceptor.LoginInterceptor;
-import team20.issuetracker.login.jwt.JwtTokenProvider;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtTokenProvider jwtTokenProvider;
-
-    public WebConfig(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+    private final LoginInterceptor loginInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
+        registry.addInterceptor(loginInterceptor)
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import lombok.RequiredArgsConstructor;
 import team20.issuetracker.login.interceptor.LoginInterceptor;
+import team20.issuetracker.login.interceptor.TokenInterceptor;
 
 @Configuration
 @EnableWebMvc
@@ -15,11 +16,18 @@ import team20.issuetracker.login.interceptor.LoginInterceptor;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;
+    private final TokenInterceptor tokenInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor)
+
+        registry.addInterceptor(tokenInterceptor)
                 .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");
+
+        registry.addInterceptor(loginInterceptor)
+                .order(2)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");
     }

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -24,12 +24,12 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(tokenInterceptor)
                 .order(1)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");
+                .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/index.html", "/login/**");
 
         registry.addInterceptor(loginInterceptor)
                 .order(2)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");
+                .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/index.html", "/login/**");
     }
 
     @Override

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -2,6 +2,7 @@ package team20.issuetracker.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -19,5 +20,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/*.ico", "/error", "/error-page/**", "/", "/index.html", "/login/**");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:9000");
     }
 }

--- a/BE/src/main/java/team20/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/team20/issuetracker/config/WebConfig.java
@@ -34,7 +34,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:9000/")
-                .allowedMethods("GET", "POST", "PATCH", "DELETE")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/BE/src/main/java/team20/issuetracker/home/HomeController.java
+++ b/BE/src/main/java/team20/issuetracker/home/HomeController.java
@@ -7,11 +7,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HomeController {
 
-    @GetMapping("/login")
-    public ResponseEntity<String> login() {
-        return ResponseEntity.ok("login");
-    }
-
     @GetMapping("/test")
     public ResponseEntity<String> error() {
         return ResponseEntity.ok("test");

--- a/BE/src/main/java/team20/issuetracker/login/domain/member/Member.java
+++ b/BE/src/main/java/team20/issuetracker/login/domain/member/Member.java
@@ -24,25 +24,25 @@ public class Member {
     private String oauthId;
     private String name;
     private String email;
-    private String avatarUrl;
+    private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     private Role role;
 
     @Builder
-    public Member(Long id, String oauthId, String name, String email, String avatarUrl, Role role) {
+    public Member(Long id, String oauthId, String name, String email, String profileImageUrl, Role role) {
         this.id = id;
         this.oauthId = oauthId;
         this.name = name;
         this.email = email;
-        this.avatarUrl = avatarUrl;
+        this.profileImageUrl = profileImageUrl;
         this.role = role;
     }
 
-    public Member update(String name, String email, String avatarUrl) {
+    public Member update(String name, String email, String profileImageUrl) {
         this.name = name;
         this.email = email;
-        this.avatarUrl = avatarUrl;
+        this.profileImageUrl = profileImageUrl;
         return this;
     }
 }

--- a/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
+++ b/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
@@ -1,6 +1,7 @@
 package team20.issuetracker.login.interceptor;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -8,6 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import team20.issuetracker.login.jwt.JwtTokenProvider;
 
+@Component
 public class LoginInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
+++ b/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
@@ -1,6 +1,7 @@
 package team20.issuetracker.login.interceptor;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -22,6 +23,10 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
         String jwtAccessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
 
         if (jwtAccessToken != null) {
             return jwtTokenProvider.validateToken(jwtAccessToken);

--- a/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
+++ b/BE/src/main/java/team20/issuetracker/login/interceptor/LoginInterceptor.java
@@ -1,7 +1,6 @@
 package team20.issuetracker.login.interceptor;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -23,10 +22,6 @@ public class LoginInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
         String jwtAccessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
-            return true;
-        }
 
         if (jwtAccessToken != null) {
             return jwtTokenProvider.validateToken(jwtAccessToken);

--- a/BE/src/main/java/team20/issuetracker/login/interceptor/TokenInterceptor.java
+++ b/BE/src/main/java/team20/issuetracker/login/interceptor/TokenInterceptor.java
@@ -2,12 +2,14 @@ package team20.issuetracker.login.interceptor;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import team20.issuetracker.exception.MyJwtException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@Component
 public class TokenInterceptor implements HandlerInterceptor {
 
     @Override

--- a/BE/src/main/java/team20/issuetracker/login/interceptor/TokenInterceptor.java
+++ b/BE/src/main/java/team20/issuetracker/login/interceptor/TokenInterceptor.java
@@ -1,0 +1,25 @@
+package team20.issuetracker.login.interceptor;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+import team20.issuetracker.exception.MyJwtException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class TokenInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String jwtAccessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String[] tokenSplit = jwtAccessToken.split(" ");
+
+        if (tokenSplit.length != 2) {
+            throw new MyJwtException("토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        return true;
+    }
+}

--- a/BE/src/main/java/team20/issuetracker/login/jwt/JwtTokenProvider.java
+++ b/BE/src/main/java/team20/issuetracker/login/jwt/JwtTokenProvider.java
@@ -80,9 +80,13 @@ public class JwtTokenProvider {
     }
 
     private String validateTokeType(String token) {
-        String tokenType = token.split(" ")[0];
-        if (!tokenType.equals(TOKEN_TYPE)) {
-            throw new MyJwtException("토큰 타입이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+        try {
+            String tokenType = token.split(" ")[0];
+            if (!tokenType.equals(TOKEN_TYPE)) {
+                throw new MyJwtException("토큰 타입이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new MyJwtException("토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
         return token.split(" ")[1];
     }

--- a/BE/src/main/java/team20/issuetracker/login/jwt/JwtTokenProvider.java
+++ b/BE/src/main/java/team20/issuetracker/login/jwt/JwtTokenProvider.java
@@ -18,6 +18,7 @@ import team20.issuetracker.exception.MyJwtException;
 @Component
 public class JwtTokenProvider {
 
+    public static final String TOKEN_TYPE = "Bearer";
     private final long accessTokenValidityInMilliseconds;
     private final long refreshTokenValidityInMilliseconds;
     private final String secretKey;
@@ -58,10 +59,18 @@ public class JwtTokenProvider {
     public boolean validateToken(String token) {
 
         try {
+            validateTokeType(token);
             Jws<Claims> claims = Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(token);
             return !claims.getBody().getExpiration().before(new Date());
         } catch (IllegalArgumentException | ExpiredJwtException e) {
             throw new MyJwtException("유효하지 않은 토큰 입니다.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    private void validateTokeType(String token) {
+        String tokenType = token.split(" ")[0];
+        if (!tokenType.equals(TOKEN_TYPE)) {
+            throw new MyJwtException("토큰 타입이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/BE/src/main/java/team20/issuetracker/login/oauth/OauthProperties.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/OauthProperties.java
@@ -29,5 +29,6 @@ public class OauthProperties {
         private String tokenUri;
         private String userInfoUri;
         private String userNameAttribute;
+        private String loginUri;
     }
 }

--- a/BE/src/main/java/team20/issuetracker/login/oauth/OauthProvider.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/OauthProvider.java
@@ -10,17 +10,19 @@ public class OauthProvider {
     private final String redirectUrl;
     private final String tokenUrl;
     private final String userInfoUrl;
+    private final String loginUri;
 
     public OauthProvider(OauthProperties.User user, OauthProperties.Provider provider) {
-        this(user.getClientId(), user.getClientSecret(), user.getRedirectUri(), provider.getTokenUri(), provider.getUserInfoUri());
+        this(user.getClientId(), user.getClientSecret(), user.getRedirectUri(), provider.getTokenUri(), provider.getUserInfoUri(), provider.getLoginUri());
     }
 
     @Builder
-    public OauthProvider(String clientId, String clientSecret, String redirectUrl, String tokenUrl, String userInfoUrl) {
+    public OauthProvider(String clientId, String clientSecret, String redirectUrl, String tokenUrl, String userInfoUrl, String loginUri) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUrl = redirectUrl;
         this.tokenUrl = tokenUrl;
         this.userInfoUrl = userInfoUrl;
+        this.loginUri = loginUri;
     }
 }

--- a/BE/src/main/java/team20/issuetracker/login/oauth/controller/OauthController.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/controller/OauthController.java
@@ -1,24 +1,30 @@
 package team20.issuetracker.login.oauth.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
 import team20.issuetracker.login.oauth.dto.LoginResponse;
 import team20.issuetracker.login.oauth.service.OauthService;
 
 @RestController
+@RequiredArgsConstructor
 public class OauthController {
 
     private final OauthService oauthService;
 
-    public OauthController(OauthService oauthService) {
-        this.oauthService = oauthService;
+    @GetMapping("/login")
+    public RedirectView getToken(RedirectAttributes redirectAttributes) {
+
+        return oauthService.getToken(redirectAttributes);
     }
 
     @GetMapping("/login/oauth/github/callback")
-    public ResponseEntity<LoginResponse> login(@RequestParam String code) {
+    public ResponseEntity<LoginResponse> login(@RequestParam String code, @RequestParam String state) {
         LoginResponse loginResponse = oauthService.signup(code);
         return ResponseEntity.ok().body(loginResponse);
     }

--- a/BE/src/main/java/team20/issuetracker/login/oauth/dto/LoginResponse.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/dto/LoginResponse.java
@@ -11,18 +11,18 @@ public class LoginResponse {
     private Long id;
     private String name;
     private String email;
-    private String avatarUrl;
+    private String profileImageUrl;
     private Role role;
     private String tokenType;
     private String accessToken;
     private String refreshToken;
 
     @Builder
-    public LoginResponse(Long id, String name, String email, String avatarUrl, Role role, String tokenType, String accessToken, String refreshToken) {
+    public LoginResponse(Long id, String name, String email, String profileImageUrl, Role role, String tokenType, String accessToken, String refreshToken) {
         this.id = id;
         this.name = name;
         this.email = email;
-        this.avatarUrl = avatarUrl;
+        this.profileImageUrl = profileImageUrl;
         this.role = role;
         this.tokenType = tokenType;
         this.accessToken = accessToken;

--- a/BE/src/main/java/team20/issuetracker/login/oauth/dto/UserProfile.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/dto/UserProfile.java
@@ -13,7 +13,9 @@ import team20.issuetracker.login.oauth.Role;
 public class UserProfile {
     @JsonProperty("id")
     private String oauthId;
+    @JsonProperty("name")
     private String email;
+    @JsonProperty("email")
     private String name;
     @JsonProperty("avatar_url")
     private String profileImageUrl;

--- a/BE/src/main/java/team20/issuetracker/login/oauth/dto/UserProfile.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/dto/UserProfile.java
@@ -16,14 +16,14 @@ public class UserProfile {
     private String email;
     private String name;
     @JsonProperty("avatar_url")
-    private String avatarUrl;
+    private String profileImageUrl;
 
     @Builder
-    public UserProfile(String oauthId, String email, String name, String avatarUrl) {
+    public UserProfile(String oauthId, String email, String name, String profileImageUrl) {
         this.oauthId = oauthId;
         this.email = email;
         this.name = name;
-        this.avatarUrl = avatarUrl;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public Member toMember() {
@@ -31,7 +31,7 @@ public class UserProfile {
                 .oauthId(oauthId)
                 .email(email)
                 .name(name)
-                .avatarUrl(avatarUrl)
+                .profileImageUrl(profileImageUrl)
                 .role(Role.GUEST)
                 .build();
     }

--- a/BE/src/main/java/team20/issuetracker/login/oauth/service/OauthService.java
+++ b/BE/src/main/java/team20/issuetracker/login/oauth/service/OauthService.java
@@ -39,7 +39,7 @@ public class OauthService {
                 .id(member.getId())
                 .name(member.getName())
                 .email(member.getEmail())
-                .avatarUrl(member.getAvatarUrl())
+                .profileImageUrl(member.getProfileImageUrl())
                 .role(member.getRole())
                 .tokenType("Bearer")
                 .accessToken(accessToken)
@@ -49,7 +49,7 @@ public class OauthService {
 
     private Member saveOrUpdate(UserProfile userProfile) {
         Member findMember = memberRepository.findByOauthId(userProfile.getOauthId())
-                .map(member -> member.update(userProfile.getEmail(), userProfile.getName(), userProfile.getAvatarUrl()))
+                .map(member -> member.update(userProfile.getEmail(), userProfile.getName(), userProfile.getProfileImageUrl()))
                 .orElseGet(userProfile::toMember);
 
         return memberRepository.save(findMember);

--- a/BE/src/main/resources/application-oauth2.yml
+++ b/BE/src/main/resources/application-oauth2.yml
@@ -4,10 +4,12 @@ oauth2:
       client-id: 2e5ceb95caa77110b9ba
       client-secret: client_secret
       redirect-uri: redirect_uri
+
   provider:
     github:
       token-uri: https://github.com/login/oauth/access_token
       user-info-uri: https://api.github.com/user
+      login-uri: https://github.com/login/oauth/authorize
 
 jwt:
   secretKey: secret_key

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -1,3 +1,3 @@
 <!--authoriazation code를 얻어오기 위한 간단한 코드-->
-<a href="https://github.com/login/oauth/authorize?client_id=2e5ceb95caa77110b9ba&scope=read:user%20user:email">
+<a href="https://github.com/login/oauth/authorize?client_id=42bec85cf9462b95d9d9&scope=read:user%20user:email">
     Github Login</a><br>

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -1,3 +1,3 @@
 <!--authoriazation code를 얻어오기 위한 간단한 코드-->
-<a href="https://github.com/login/oauth/authorize?client_id=42bec85cf9462b95d9d9&scope=read:user%20user:email">
+<a href="https://github.com/login/oauth/authorize?client_id=4d2b05458925bce5b37b&scope=read:user%20user:email">
     Github Login</a><br>

--- a/FE/src/components/Comment/index.tsx
+++ b/FE/src/components/Comment/index.tsx
@@ -3,7 +3,7 @@ import UserProfile from '../common/UserProfile';
 import * as S from './style';
 import { CommentProps } from './type';
 
-import { Emoji } from '@/icons/emoji';
+import { Emoji } from '@/icons/Emoji';
 import { getRelativeTime } from '@/utils/issue';
 
 const Comment = ({ issueAuthor, userId, imgUrl, createTime, description }: CommentProps) => {


### PR DESCRIPTION
안녕하세요 ! team-20 백엔드 타니 & 검봉입니다.

issue-tracker 프로젝트 3주차 세 번째 PR요청 보냅니다.

이번 주는 GitHub OAuth Intercepter 추가, ERD 초안 작성 및 CloudFront, S3, GitHub Action 을 통한 자동배포를 진행했습니다.

ERD 는 Entity 추가 및 매핑 완료 후 금요일 PR 에 올리도록 하겠습니다.

## 구현 예정 사항
- 이슈 API 개발 시작

## 궁금한 점
#### CORS 관련 궁금증
1. GitHub OAuth API 설정
<img width="488" alt="OAuth application settings" src="https://user-images.githubusercontent.com/79444040/176397154-a9e1603d-4bad-496d-88ea-369809a1a871.png">

1. 최초 저희가 GitHub OAuth 를 구현할 때, FE 쪽에서 Authorization Code 를 받아낸 뒤 서버에서는 코드를 받아내 사용자 정보 및 Token 을 다시 FE 쪽으로 응답하는 방식으로 진행을 했습니다. 하지만 FE 쪽에서 요청을 보낼 때, 서버를 거쳐  리소스 서버(GitHub) 로 보내는 것이 아닌 바로 리소스 서버로 요청을  보내기 때문에 서버는 FE 에서 받은 Authorization Code 를 callback API 를 통해 처리해 FE 쪽으로 응답을 보내도 FE 에서는 서버로 요청을 보내지 않았기 때문에 JSON 데이터 응답을 받아낼 수 없었습니다. 
(이 부분에 관해서는 FE 분이 말씀해주시길 Request 가 없는데 어떻게 Response 를 받을 수 있을까요? 라고 해주시긴 했습니다.)

3. 따라서 FE 에서 바로 리소스 서버로 접근해 Authorization Code 를 받아내는 것이 아닌, 서버에 임의의 API `(현재 OauthController 의 getToken() 메서드입니다.)` 로 로그인 버튼을 클릭하는 요청만 보내면 서버 쪽에서 리소스 서버로 접근해 Authorization Code 를 받고, RedirectView 를 통해 callback API 를 처리하는 식으로 구조를 변경했습니다.

4. 정리하자면 ..
 #### 원래 구현 상황 
   - FE -> 리소스 서버 -> FE 에서 서버로 Authorization Code 전달 -> 서버에서 callback 처리 후 유저 정보 및 토큰 FE 로 전달 </br>
 #### 바뀐 구현 상황
   -  FE -> 서버 -> 서버에서 리소스 서버에 접근해 Authorization Code 얻어온 뒤 callback 으로 리다이렉트 -> 유저 정보 및 토큰 FE 로 전달 

5. CORS 문제
<img width="812" alt="image" src="https://user-images.githubusercontent.com/79444040/176396298-cc7b9f3c-fddf-4ee0-a3f1-9c7af1d1427d.png">
- CORS 문제가 당연히 발생할 것이므로 서버에서 Interceptor 를 통해 localhost:9000 포트를 허용해줬습니다. FE 에서 로그인 버튼을 클릭했을 떄 `/login` 을 타게되는데, 여기는 저희가 포트를 허용했기 때문에 문제 없이 지나가지만, 깃허브에서 로그인하는 창 쪽에서 CORS 문제가 계속 터지고 있는 상황입니다. GitHub 리소스 서버 헤더에 저희가 CORS 허용을 넣을 수는 없을 것 같고 .. 어떻게 해결해야하는지 잘 모르겠어서 질문을 남기게 되었습니다 🥲

- 중구난방으로 작성해서 이해가 어려우실 것 같습니다 죄송합니다 ㅠㅠ...
