### PR TITLE
[team-34 | dony & hemdi] 3주차 1번째 PR 요청

### DIFF
--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError } from 'axios';
+import { AxiosType } from '@/api/type';
 
 const baseURL = 'https://0fc30a5e-96f5-446a-8ad1-7be878b3b9cb.mock.pstmn.io/api';
 
@@ -31,13 +32,6 @@ const handleError = (err: AxiosError) => {
   }
 
   return { data: null, status: null };
-};
-
-type AxiosType = {
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
-  url: string;
-  data?: { [key: string]: string };
-  config?: AxiosRequestConfig;
 };
 
 const requestApi = async ({ method, url, data, config }: AxiosType) => {

--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { AxiosType } from '@/api/type';
 
-const baseURL = 'https://85351621-920e-4834-bd3e-7d9e2f09b244.mock.pstmn.io/api';
+const baseURL = 'https://aa974b35-fbc4-4ee2-9b06-8960e6c6f57d.mock.pstmn.io/api';
 
 const instance = axios.create({
   baseURL: baseURL,

--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { AxiosType } from '@/api/type';
 
-const baseURL = 'https://fd7da552-08a3-42fa-8ddc-0d1aaac9c7ad.mock.pstmn.io/api';
+const baseURL = 'https://85351621-920e-4834-bd3e-7d9e2f09b244.mock.pstmn.io/api';
 
 const instance = axios.create({
   baseURL: baseURL,

--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { AxiosType } from '@/api/type';
 
-const baseURL = 'https://fd7da552-08a3-42fa-8ddc-0d1aaac9c7ad.mock.pstmn.io/api';
+const baseURL = 'https://85351621-920e-4834-bd3e-7d9e2f09b244.mock.pstmn.io/api';
 
 const instance = axios.create({
   baseURL: baseURL,
@@ -15,20 +15,20 @@ const handleError = (err: AxiosError) => {
     const { baseURL = '', url = '' } = config;
 
     if (status === 404) {
-      console.log(`${baseURL + url} not found`);
+      console.error(`${baseURL + url} not found`);
     }
 
     if (status === 500) {
-      console.log(`Server error`);
+      console.error(`Server error`);
     }
     return err.response;
   }
 
   if (err.request) {
     // 요청이 전송되었지만, 응답이 수신되지 않았습니다.
-    console.log('Error', err.message);
+    console.error('Error', err.message);
   } else {
-    console.log('Error', err.message);
+    console.error('Error', err.message);
   }
 
   return { data: null, status: null };

--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import { AxiosType } from '@/api/type';
 
-const baseURL = 'https://0fc30a5e-96f5-446a-8ad1-7be878b3b9cb.mock.pstmn.io/api';
+const baseURL = 'https://fd7da552-08a3-42fa-8ddc-0d1aaac9c7ad.mock.pstmn.io/api';
 
 const instance = axios.create({
   baseURL: baseURL,

--- a/FE/src/api/core.ts
+++ b/FE/src/api/core.ts
@@ -8,6 +8,12 @@ const instance = axios.create({
   timeout: 2000 // 응답 대기 최대 시간
 });
 
+instance.interceptors.request.use(config => {
+  const currentUserToken = localStorage.getItem('currentUserToken');
+  config.headers!.Authorization = currentUserToken ? `Bearer ${currentUserToken}` : '';
+  return config;
+});
+
 const handleError = (err: AxiosError) => {
   if (err.response) {
     // 요청이 전송되었고, 서버는 2xx 외의 상태 코드로 응답했습니다.

--- a/FE/src/api/githubOauth.ts
+++ b/FE/src/api/githubOauth.ts
@@ -9,8 +9,8 @@ const getLoginToken = async (data: any) =>
   await requestApi({
     method: 'get',
     url: '/login/oauth/github/callback?code=12345678',
-    data
-    // config: { withCredentials: true }  //-> 쿠키를 추가해주기 위한 옵션(현재 CORS ERROR 발생)
+    data,
+    config: { withCredentials: true }
   });
 
 export { getLoginURL, getLoginToken };

--- a/FE/src/api/githubOauth.ts
+++ b/FE/src/api/githubOauth.ts
@@ -2,14 +2,13 @@ import { requestApi } from '@/api/core';
 const getLoginURL = async () =>
   await requestApi({
     method: 'get',
-    url: '/login/oauth/github'
+    url: '/login/oauth2/github'
   });
 
-const getLoginToken = async (data: any) =>
+const getLoginToken = async (code: string) =>
   await requestApi({
     method: 'get',
-    url: '/login/oauth/github/callback?code=12345678',
-    data,
+    url: `/login/oauth2/github/callback?code=${code}`,
     config: { withCredentials: true }
   });
 

--- a/FE/src/api/issueList.ts
+++ b/FE/src/api/issueList.ts
@@ -1,19 +1,21 @@
 import { requestApi } from '@/api/core';
 import { IssueStateType } from '@/api/type';
 
-const getIssueList = async (state: IssueStateType) => {
+const getIssueList = async (status: IssueStateType) => {
   const issueList = await requestApi({
     method: 'get',
-    url: `/issues?state=${state}`
+    url: `/issues?${status ? `state=${status}` : ''}`
   });
+
   return issueList;
 };
 
-const getIssueCount = async (state: IssueStateType) => {
+const getIssueCount = async (status: IssueStateType) => {
   const issueCount = await requestApi({
     method: 'get',
-    url: `/issues/counts?state=${state}`
+    url: `/issues/counts?${status ? `state=${status}` : ''}`
   });
+
   return issueCount;
 };
 

--- a/FE/src/api/issueList.ts
+++ b/FE/src/api/issueList.ts
@@ -1,0 +1,20 @@
+import { requestApi } from '@/api/core';
+import { IssueStateType } from '@/api/type';
+
+const getIssueList = async (state: IssueStateType) => {
+  const issueList = await requestApi({
+    method: 'get',
+    url: `/issues?state=${state}`
+  });
+  return issueList;
+};
+
+const getIssueCount = async (state: IssueStateType) => {
+  const issueCount = await requestApi({
+    method: 'get',
+    url: `/issues/counts?state=${state}`
+  });
+  return issueCount;
+};
+
+export { getIssueList, getIssueCount };

--- a/FE/src/api/issueList.ts
+++ b/FE/src/api/issueList.ts
@@ -4,7 +4,7 @@ import { IssueStateType } from '@/api/type';
 const getIssueList = async (status: IssueStateType) => {
   const issueList = await requestApi({
     method: 'get',
-    url: `/issues?${status ? `state=${status}` : ''}`
+    url: `/issues${status ? `?state=${status}` : ''}`
   });
 
   return issueList;
@@ -13,7 +13,7 @@ const getIssueList = async (status: IssueStateType) => {
 const getIssueCount = async (status: IssueStateType) => {
   const issueCount = await requestApi({
     method: 'get',
-    url: `/issues/counts?${status ? `state=${status}` : ''}`
+    url: `/issues/counts${status ? `?state=${status}` : ''}`
   });
 
   return issueCount;

--- a/FE/src/api/issueList.ts
+++ b/FE/src/api/issueList.ts
@@ -1,7 +1,7 @@
 import { requestApi } from '@/api/core';
-import { IssueStateType } from '@/api/type';
+import { APIIssueStatusType } from '@/api/type';
 
-const getIssueList = async (status: IssueStateType) => {
+const getIssueList = async (status?: APIIssueStatusType) => {
   const issueList = await requestApi({
     method: 'get',
     url: `/issues?${status ? `state=${status}` : ''}`
@@ -10,7 +10,7 @@ const getIssueList = async (status: IssueStateType) => {
   return issueList;
 };
 
-const getIssueCount = async (status: IssueStateType) => {
+const getIssueCount = async (status?: APIIssueStatusType) => {
   const issueCount = await requestApi({
     method: 'get',
     url: `/issues/counts?${status ? `state=${status}` : ''}`

--- a/FE/src/api/labels.ts
+++ b/FE/src/api/labels.ts
@@ -1,0 +1,21 @@
+import { requestApi } from '@/api/core';
+
+const getLabelList = async () => {
+  const labelList = await requestApi({
+    method: 'get',
+    url: '/labels'
+  });
+
+  return labelList;
+};
+
+const getLabelCount = async () => {
+  const labelCount = await requestApi({
+    method: 'get',
+    url: '/labels/counts'
+  });
+
+  return labelCount;
+};
+
+export { getLabelList, getLabelCount };

--- a/FE/src/api/members.ts
+++ b/FE/src/api/members.ts
@@ -1,0 +1,21 @@
+import { requestApi } from '@/api/core';
+
+const getMemberList = async () => {
+  const memberList = await requestApi({
+    method: 'get',
+    url: '/members'
+  });
+
+  return memberList;
+};
+
+const getCurrentMember = async () => {
+  const currentMember = await requestApi({
+    method: 'get',
+    url: '/members/current'
+  });
+
+  return currentMember;
+};
+
+export { getMemberList, getCurrentMember };

--- a/FE/src/api/milestones.ts
+++ b/FE/src/api/milestones.ts
@@ -1,0 +1,21 @@
+import { requestApi } from '@/api/core';
+
+const getMilestoneList = async () => {
+  const milestoneList = await requestApi({
+    method: 'get',
+    url: '/milestones'
+  });
+
+  return milestoneList;
+};
+
+const getMilestoneCount = async () => {
+  const milestoneCount = await requestApi({
+    method: 'get',
+    url: '/milestones/counts'
+  });
+
+  return milestoneCount;
+};
+
+export { getMilestoneList, getMilestoneCount };

--- a/FE/src/api/queryKeys.ts
+++ b/FE/src/api/queryKeys.ts
@@ -1,13 +1,17 @@
 const issueListQueryKeys = {
-  all: ['issueList'],
-  open: ['issueList', { status: 'open' }],
-  close: ['issueList', { status: 'close' }]
+  all: ['issue'],
+  open: ['issue', { status: 'open' }],
+  close: ['issue', { status: 'close' }]
 };
 
-const issueListCountQueryKeys = {
-  all: ['issueList', 'count'],
-  open: ['issueList', { status: 'open' }, 'count'],
-  close: ['issueList', { status: 'close' }, 'count']
+const issueCountQueryKeys = {
+  all: ['issue', 'count'],
+  open: ['issue', { status: 'open' }, 'count'],
+  close: ['issue', { status: 'close' }, 'count']
 };
 
-export { issueListQueryKeys, issueListCountQueryKeys };
+const labelListQueryKeys = ['label'];
+
+const labelCountQueryKeys = ['label', 'count'];
+
+export { issueListQueryKeys, issueCountQueryKeys, labelListQueryKeys, labelCountQueryKeys };

--- a/FE/src/api/queryKeys.ts
+++ b/FE/src/api/queryKeys.ts
@@ -1,0 +1,13 @@
+const issueListQueryKeys = {
+  all: ['issueList'],
+  open: ['issueList', { status: 'open' }],
+  close: ['issueList', { status: 'close' }]
+};
+
+const issueListCountQueryKeys = {
+  all: ['issueList', 'count'],
+  open: ['issueList', { status: 'open' }, 'count'],
+  close: ['issueList', { status: 'close' }, 'count']
+};
+
+export { issueListQueryKeys, issueListCountQueryKeys };

--- a/FE/src/api/queryKeys.ts
+++ b/FE/src/api/queryKeys.ts
@@ -14,4 +14,15 @@ const labelListQueryKeys = ['label'];
 
 const labelCountQueryKeys = ['label', 'count'];
 
-export { issueListQueryKeys, issueCountQueryKeys, labelListQueryKeys, labelCountQueryKeys };
+const milestoneListQueryKeys = ['milestone'];
+
+const milestoneCountQueryKeys = ['milestone', 'count'];
+
+export {
+  issueListQueryKeys,
+  issueCountQueryKeys,
+  labelListQueryKeys,
+  labelCountQueryKeys,
+  milestoneListQueryKeys,
+  milestoneCountQueryKeys
+};

--- a/FE/src/api/queryKeys.ts
+++ b/FE/src/api/queryKeys.ts
@@ -18,11 +18,17 @@ const milestoneListQueryKeys = ['milestone'];
 
 const milestoneCountQueryKeys = ['milestone', 'count'];
 
+const memberListQueryKeys = ['members'];
+
+const currentMemberQueryKeys = ['members', 'current'];
+
 export {
   issueListQueryKeys,
   issueCountQueryKeys,
   labelListQueryKeys,
   labelCountQueryKeys,
   milestoneListQueryKeys,
-  milestoneCountQueryKeys
+  milestoneCountQueryKeys,
+  memberListQueryKeys,
+  currentMemberQueryKeys
 };

--- a/FE/src/api/type.ts
+++ b/FE/src/api/type.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 
-type IssueStateType = 'open' | 'close';
+type IssueStateType = 'open' | 'close' | undefined;
 
 type AxiosType = {
   method: 'get' | 'post' | 'put' | 'delete' | 'patch';

--- a/FE/src/api/type.ts
+++ b/FE/src/api/type.ts
@@ -1,0 +1,12 @@
+import { AxiosRequestConfig } from 'axios';
+
+type IssueStateType = 'open' | 'close';
+
+type AxiosType = {
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  url: string;
+  data?: { [key: string]: string };
+  config?: AxiosRequestConfig;
+};
+
+export type { IssueStateType, AxiosType };

--- a/FE/src/api/type.ts
+++ b/FE/src/api/type.ts
@@ -1,6 +1,4 @@
-import { AxiosRequestConfig } from 'axios';
-
-type IssueStateType = 'open' | 'close' | undefined;
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 type AxiosType = {
   method: 'get' | 'post' | 'put' | 'delete' | 'patch';
@@ -9,4 +7,13 @@ type AxiosType = {
   config?: AxiosRequestConfig;
 };
 
-export type { IssueStateType, AxiosType };
+type APIIssueStatusType = 'open' | 'close' | undefined;
+
+type APIResponse =
+  | AxiosResponse<any, any>
+  | {
+      data: null;
+      status: null;
+    };
+
+export type { AxiosType, APIIssueStatusType, APIResponse };

--- a/FE/src/components/Header/index.tsx
+++ b/FE/src/components/Header/index.tsx
@@ -1,19 +1,15 @@
 import Logo from '@/components/common/Logo';
 import UserProfile from '@/components/common/UserProfile';
 import { $Header } from '@/components/Header/style';
+import { getCurrentUserInfoOf } from '@/utils/user';
 import { useEffect, useState } from 'react';
 
 export default function Header() {
   const [profileURL, setProfileURL] = useState('/');
 
   useEffect(() => {
-    const currentUserInfo = localStorage.getItem('currentUserInfo');
-
-    if (!currentUserInfo) return;
-
-    const { image_url } = JSON.parse(currentUserInfo);
-
-    setProfileURL(image_url);
+    const profileURL = getCurrentUserInfoOf('image_url');
+    setProfileURL(profileURL ? (profileURL as string) : '');
   });
 
   return (

--- a/FE/src/components/IssueList/FilterBar/index.tsx
+++ b/FE/src/components/IssueList/FilterBar/index.tsx
@@ -56,6 +56,7 @@ export default function FilterBar({
         <Icon iconType="search" color={inputInfo.value !== '' ? COLOR.label : COLOR.placeholder} />
         <TextInput
           status={null}
+          width="100%"
           height="36px"
           padding="0 10px"
           borderRadius="0"

--- a/FE/src/components/IssueList/FilterBar/index.tsx
+++ b/FE/src/components/IssueList/FilterBar/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { COLOR } from '@/styles/common';
 import { $FilterBar, $InputWrapper } from '@/components/IssueList/FilterBar/style';
 import { IFilterBarProps } from '@/components/IssueList/FilterBar/type';
@@ -6,6 +6,11 @@ import useInputTextValue from '@/hooks/useInputTextValue';
 import { Icon } from '@/components/common/Icon';
 import TextInput from '@/components/common/TextInput';
 import Dropdown from '@/components/common/Dropdown';
+import { useFilterCondition, useFilterConditionDispatch } from '@/contexts/FilterCondition';
+import {
+  createFilterConditionString,
+  InitFilterCondition
+} from '@/contexts/FilterCondition/reducer';
 
 const TEXT_INPUT_DEBOUNCE_TIME = 0;
 const TEXT_INPUT_INIT_VALUE = 'is:issue is:open';
@@ -28,6 +33,13 @@ export default function FilterBar({
 }: IFilterBarProps) {
   const { inputInfo, updateInputValue } = useInputTextValue<InputName>(TEXT_INPUT_INIT_VALUE);
   const [isFocus, setIsFocus] = useState(false);
+  const filterConditionContext = useFilterCondition();
+  const dispatch = useFilterConditionDispatch();
+
+  useEffect(() => {
+    const filterConditionString = createFilterConditionString(filterConditionContext);
+    updateInputValue('search', filterConditionString, TEXT_INPUT_DEBOUNCE_TIME);
+  }, [filterConditionContext]);
 
   return (
     <$FilterBar isFocus={isFocus}>
@@ -48,6 +60,7 @@ export default function FilterBar({
           padding="0 10px"
           borderRadius="0"
           styleType={inputStyleType}
+          value={inputInfo.value}
           {...inputProps}
           focusStyle={focusStyle}
           handleChange={({ name, value }: { name: InputName; value: string }) =>

--- a/FE/src/components/IssueList/FilterBar/style.ts
+++ b/FE/src/components/IssueList/FilterBar/style.ts
@@ -17,19 +17,14 @@ const $FilterBar = styled.div<I$FilterBar>`
   border: 1px solid ${({ theme }) => theme.COLOR.line};
   border-radius: 11px;
   ${({ isFocus }) => isFocus && focusStyle}
-  overflow: hidden;
 `;
 
 const $InputWrapper = styled.div`
   display: flex;
-  padding: 0 0 0 24px;
+  padding: 0 11px 0 24px;
   align-items: center;
   flex: 1;
   border-left: 1px solid ${({ theme }) => theme.COLOR.line};
-  background-color: ${({ theme }) => theme.COLOR.inputBackground};
-  :focus-within {
-    background-color: ${({ theme }) => theme.PALETTE.WHITE};
-  }
 `;
 
 export { $FilterBar, $InputWrapper };

--- a/FE/src/components/IssueList/FilterBar/style.ts
+++ b/FE/src/components/IssueList/FilterBar/style.ts
@@ -17,14 +17,19 @@ const $FilterBar = styled.div<I$FilterBar>`
   border: 1px solid ${({ theme }) => theme.COLOR.line};
   border-radius: 11px;
   ${({ isFocus }) => isFocus && focusStyle}
+  overflow: hidden;
 `;
 
 const $InputWrapper = styled.div`
   display: flex;
-  padding: 0 24px;
+  padding: 0 0 0 24px;
   align-items: center;
   flex: 1;
   border-left: 1px solid ${({ theme }) => theme.COLOR.line};
+  background-color: ${({ theme }) => theme.COLOR.inputBackground};
+  :focus-within {
+    background-color: ${({ theme }) => theme.PALETTE.WHITE};
+  }
 `;
 
 export { $FilterBar, $InputWrapper };

--- a/FE/src/components/IssueList/IssueListFilterDropDowns/index.tsx
+++ b/FE/src/components/IssueList/IssueListFilterDropDowns/index.tsx
@@ -1,49 +1,89 @@
 import Dropdown from '@/components/common/Dropdown';
 import { Icon } from '@/components/common/Icon';
-import { $IssueListFilterDropDowns } from '@/components/IssueList/IssueListFilterDropDowns/style';
-import mockData from '@/components/IssueList/mockData';
+import {
+  $IssueListFilterDropDowns,
+  $IssueListFIlterSelect
+} from '@/components/IssueList/IssueListFilterDropDowns/style';
+import UserProfile from '@/components/common/UserProfile';
+import { useMemberListData } from '@/hooks/useMemberListData';
+import { useLabelListData } from '@/hooks/useLabelListData';
+import { useMilestoneListData } from '@/hooks/useMilestoneListData';
+import {
+  IMemberData,
+  ILabelData,
+  IMilestoneData
+} from '@/components/IssueList/IssueListFilterDropDowns/type';
 
 const radioIcon = {
   off: <Icon iconType="radioOff" />,
   on: <Icon iconType="radioOn" />
 };
 
-const ISSUE_FILTERS_PROPS = [
-  {
-    indicatorName: '담당자',
-    panelName: '담당자 필터',
-    dataName: 'labelList'
-  },
-  {
-    indicatorName: '레이블',
-    panelName: '레이블 필터',
-    dataName: 'labelList'
-  },
-  {
-    indicatorName: '마일스톤',
-    panelName: '마일스톤 필터',
-    dataName: 'milestoneList'
-  },
-  {
-    indicatorName: '작성자',
-    panelName: '작성자 필터',
-    dataName: 'milestoneList'
-  }
-];
-
 export default function IssueListFilterDropDowns() {
-  const getIssueFilterOptions = (dataName: 'labelList' | 'milestoneList') => {
-    const options = mockData[dataName].map(
-      ({ name, description }: { name: string; description: string }) => {
-        return {
-          children: name,
-          radio: radioIcon,
-          value: description
-        };
-      }
-    );
+  const { status: memberDataStatus, data: memberList } = useMemberListData();
+  const { status: labelDataStatus, data: labelList } = useLabelListData();
+  const { status: milestoneDataStatus, data: milestoneList } = useMilestoneListData();
 
-    return options;
+  const ISSUE_FILTERS_PROPS = [
+    {
+      indicatorName: '담당자',
+      panelName: '담당자 필터',
+      dataName: 'memberList'
+    },
+    {
+      indicatorName: '레이블',
+      panelName: '레이블 필터',
+      dataName: 'labelList'
+    },
+    {
+      indicatorName: '마일스톤',
+      panelName: '마일스톤 필터',
+      dataName: 'milestoneList'
+    },
+    {
+      indicatorName: '작성자',
+      panelName: '작성자 필터',
+      dataName: 'memberList'
+    }
+  ];
+
+  const getIssueFilterOptions = (dataName: string) => {
+    switch (dataName) {
+      case 'memberList':
+        const optionData = memberList ? memberList?.data.data : [];
+        return optionData.map(({ user_id, image_url }: IMemberData) => {
+          return {
+            children: (
+              <$IssueListFIlterSelect>
+                <UserProfile src={image_url} size="small" />
+                {user_id}
+              </$IssueListFIlterSelect>
+            ),
+            radio: radioIcon,
+            value: user_id
+          };
+        });
+      case 'labelList': {
+        const optionData = labelList ? labelList.data.data : [];
+        return optionData.map(({ name, description }: ILabelData) => {
+          return {
+            children: name,
+            radio: radioIcon,
+            value: description
+          };
+        });
+      }
+      case 'milestoneList': {
+        const optionData = milestoneList ? milestoneList.data.data : [];
+        return optionData.map(({ name, description }: IMilestoneData) => {
+          return {
+            children: name,
+            radio: radioIcon,
+            value: description
+          };
+        });
+      }
+    }
   };
 
   return (

--- a/FE/src/components/IssueList/IssueListFilterDropDowns/index.tsx
+++ b/FE/src/components/IssueList/IssueListFilterDropDowns/index.tsx
@@ -28,28 +28,28 @@ export default function IssueListFilterDropDowns() {
     {
       indicatorName: '담당자',
       panelName: '담당자 필터',
-      dataName: 'memberList'
+      filterName: 'assignee'
     },
     {
       indicatorName: '레이블',
       panelName: '레이블 필터',
-      dataName: 'labelList'
+      filterName: 'label'
     },
     {
       indicatorName: '마일스톤',
       panelName: '마일스톤 필터',
-      dataName: 'milestoneList'
+      filterName: 'milestone'
     },
     {
       indicatorName: '작성자',
       panelName: '작성자 필터',
-      dataName: 'memberList'
+      filterName: 'author'
     }
   ];
 
-  const getIssueFilterOptions = (dataName: string) => {
-    switch (dataName) {
-      case 'memberList':
+  const getIssueFilterOptions = (filterName: string) => {
+    switch (filterName) {
+      case 'assignee':
         const optionData = memberList ? memberList?.data.data : [];
         return optionData.map(({ user_id, image_url }: IMemberData) => {
           return {
@@ -60,26 +60,53 @@ export default function IssueListFilterDropDowns() {
               </$IssueListFIlterSelect>
             ),
             radio: radioIcon,
-            value: user_id
+            value: user_id,
+            filterCondition: {
+              assignee: user_id
+            }
           };
         });
-      case 'labelList': {
+      case 'label': {
         const optionData = labelList ? labelList.data.data : [];
         return optionData.map(({ name, description }: ILabelData) => {
           return {
             children: name,
             radio: radioIcon,
-            value: description
+            value: description,
+            filterCondition: {
+              label: name
+            }
           };
         });
       }
-      case 'milestoneList': {
+      case 'milestone': {
         const optionData = milestoneList ? milestoneList.data.data : [];
         return optionData.map(({ name, description }: IMilestoneData) => {
           return {
             children: name,
             radio: radioIcon,
-            value: description
+            value: description,
+            filterCondition: {
+              milestone: name
+            }
+          };
+        });
+      }
+      case 'author': {
+        const optionData = memberList ? memberList?.data.data : [];
+        return optionData.map(({ user_id, image_url }: IMemberData) => {
+          return {
+            children: (
+              <$IssueListFIlterSelect>
+                <UserProfile src={image_url} size="small" />
+                {user_id}
+              </$IssueListFIlterSelect>
+            ),
+            radio: radioIcon,
+            value: user_id,
+            filterCondition: {
+              author: user_id
+            }
           };
         });
       }
@@ -88,8 +115,8 @@ export default function IssueListFilterDropDowns() {
 
   return (
     <$IssueListFilterDropDowns>
-      {ISSUE_FILTERS_PROPS.map(({ dataName, ...props }, idx) => (
-        <Dropdown key={idx} left="right" options={getIssueFilterOptions(dataName)} {...props} />
+      {ISSUE_FILTERS_PROPS.map(({ filterName, ...props }, idx) => (
+        <Dropdown key={idx} left="right" options={getIssueFilterOptions(filterName)} {...props} />
       ))}
     </$IssueListFilterDropDowns>
   );

--- a/FE/src/components/IssueList/IssueListFilterDropDowns/style.ts
+++ b/FE/src/components/IssueList/IssueListFilterDropDowns/style.ts
@@ -7,4 +7,9 @@ const $IssueListFilterDropDowns = styled.div`
   justify-content: space-between;
 `;
 
-export { $IssueListFilterDropDowns };
+const $IssueListFIlterSelect = styled.span`
+  display: flex;
+  gap: 8px;
+`;
+
+export { $IssueListFilterDropDowns, $IssueListFIlterSelect };

--- a/FE/src/components/IssueList/IssueListFilterDropDowns/type.ts
+++ b/FE/src/components/IssueList/IssueListFilterDropDowns/type.ts
@@ -1,0 +1,13 @@
+interface IMemberData {
+  user_id: string;
+  image_url: string;
+}
+
+interface ILabelData {
+  name: string;
+  description: string;
+}
+
+interface IMilestoneData extends ILabelData {}
+
+export type { IMemberData, ILabelData, IMilestoneData };

--- a/FE/src/components/IssueList/IssueListTabs/index.tsx
+++ b/FE/src/components/IssueList/IssueListTabs/index.tsx
@@ -12,11 +12,17 @@ export default function IssueListTabs() {
   const dispatch = useFilterConditionDispatch();
   const { isSuccess: isSuccessOfOpen, data: issueOpenCounts } = useIssueCountData('open');
   const { isSuccess: isSuccessOfClose, data: issueCloseCounts } = useIssueCountData('close');
+
+  const handleTabClick = (status: IssueStatusType) => () => {
+    setCondition(dispatch, { status });
+  };
+
   return (
     <$IssueListTabs>
       <Button
         styleType="mediumText"
         color={currentStatus === 'OPEN' ? COLOR.title : ''}
+        onClick={handleTabClick('OPEN')}
       >
         <Icon iconType="openLabel" />
         {`열린 이슈 ${isSuccessOfOpen ? `(${issueOpenCounts?.data.total_count})` : ''}`}
@@ -24,6 +30,7 @@ export default function IssueListTabs() {
       <Button
         styleType="mediumText"
         color={currentStatus === 'CLOSE' ? COLOR.title : ''}
+        onClick={handleTabClick('CLOSE')}
       >
         <Icon iconType="closeLabel" />
         {`닫힌 이슈 ${isSuccessOfClose ? `(${issueCloseCounts?.data.total_count})` : ''}`}

--- a/FE/src/components/IssueList/IssueListTabs/index.tsx
+++ b/FE/src/components/IssueList/IssueListTabs/index.tsx
@@ -1,17 +1,32 @@
 import Button from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
 import { $IssueListTabs } from '@/components/IssueList/IssueListTabs/style';
+import { useFilterCondition, useFilterConditionDispatch } from '@/contexts/FilterCondition';
+import { setCondition } from '@/contexts/FilterCondition/action';
+import { useIssueCountData } from '@/hooks/useIssueListData';
+import { COLOR } from '@/styles/common';
+import { IssueStatusType } from '@/types/common';
 
 export default function IssueListTabs() {
+  const { status: currentStatus } = useFilterCondition();
+  const dispatch = useFilterConditionDispatch();
+  const { isSuccess: isSuccessOfOpen, data: issueOpenCounts } = useIssueCountData('open');
+  const { isSuccess: isSuccessOfClose, data: issueCloseCounts } = useIssueCountData('close');
   return (
     <$IssueListTabs>
-      <Button styleType="mediumText">
+      <Button
+        styleType="mediumText"
+        color={currentStatus === 'OPEN' ? COLOR.title : ''}
+      >
         <Icon iconType="openLabel" />
-        {`열린 이슈(2)`}
+        {`열린 이슈 ${isSuccessOfOpen ? `(${issueOpenCounts?.data.total_count})` : ''}`}
       </Button>
-      <Button styleType="mediumText">
+      <Button
+        styleType="mediumText"
+        color={currentStatus === 'CLOSE' ? COLOR.title : ''}
+      >
         <Icon iconType="closeLabel" />
-        {`닫힌 이슈(0)`}
+        {`닫힌 이슈 ${isSuccessOfClose ? `(${issueCloseCounts?.data.total_count})` : ''}`}
       </Button>
     </$IssueListTabs>
   );

--- a/FE/src/components/IssueList/ListItem/index.tsx
+++ b/FE/src/components/IssueList/ListItem/index.tsx
@@ -1,18 +1,19 @@
 import Button from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
 import { $ListItem, $Contents, $Title, $Info, $Text } from '@/components/IssueList/ListItem/style';
-import { IListItem } from '@/components/IssueList/ListItem/type';
+import { ILabel, IListItem } from '@/components/IssueList/ListItem/type';
 import Label from '@/components/common/Label';
 import UserProfile from '@/components/common/UserProfile';
 
 export default function ListItem({
+  id,
   title,
-  labelList,
-  number,
+  status,
+  assignees,
   author,
-  timestamp,
-  milestone,
-  status
+  created_at,
+  labels,
+  milestone
 }: IListItem) {
   return (
     <$ListItem>
@@ -22,23 +23,25 @@ export default function ListItem({
           <$Text as="h3" size="large">
             {title}
           </$Text>
-          {labelList &&
-            labelList.map((value: string) => (
-              <Label key={value} size="small" status="dark">
-                {value}
+          {labels &&
+            labels.map(({ id, name, color_code }: ILabel) => (
+              <Label key={id} size="small" status="dark" background={color_code}>
+                {name}
               </Label>
             ))}
         </$Title>
         <$Info>
-          <$Text size="small">{`#${number}`}</$Text>
+          <$Text size="small">{`#${id}`}</$Text>
           <$Text as="p" size="small">{`이 이슈가 ${author?.name}님에 의해 작성되었습니다.`}</$Text>
-          <Button styleType="mediumText" gap="8px" fontWeight="normal">
-            <Icon iconType="milestone" />
-            {milestone}
-          </Button>
+          {milestone && (
+            <Button styleType="mediumText" gap="8px" fontWeight="normal">
+              <Icon iconType="milestone" />
+              {milestone?.name}
+            </Button>
+          )}
         </$Info>
       </$Contents>
-      <UserProfile src={author?.profile} size="small" />
+      <UserProfile src={author?.image_url} size="small" />
     </$ListItem>
   );
 }

--- a/FE/src/components/IssueList/ListItem/type.ts
+++ b/FE/src/components/IssueList/ListItem/type.ts
@@ -1,33 +1,38 @@
-interface IAuthor {
-  userId: string;
-  name: string;
-  profile: string;
-}
+import { IssueStatusType } from '@/types/common';
 
-interface IListItem {
-  title: string;
-  labelList: string[];
-  number: number;
-  author: IAuthor;
-  timestamp: string;
-  milestone: string;
-  status: 'OPEN' | 'CLOSE';
+interface IMember {
+  id: number;
+  image_url: string;
+  user_id: string;
+  name: string;
 }
 
 interface ILabel {
   id: number;
   name: string;
-  description: string;
   color_code: string;
+  description: string;
 }
 
 interface IMilestone {
   id: number;
   name: string;
+  status: IssueStatusType;
   description: string;
   target_date: string;
   open_issue: number;
   closed_issue: number;
+}
+
+interface IListItem {
+  id: number;
+  title: string;
+  status: IssueStatusType;
+  assignees: IMember[];
+  author: IMember;
+  created_at: string;
+  labels: ILabel[];
+  milestone: IMilestone;
 }
 
 interface MockData {
@@ -40,4 +45,4 @@ interface I$Text {
   size: 'large' | 'small';
 }
 
-export type { IListItem, ILabel, IMilestone, MockData, I$Text };
+export type { IListItem, IMember, ILabel, IMilestone, MockData, I$Text };

--- a/FE/src/components/IssueList/index.tsx
+++ b/FE/src/components/IssueList/index.tsx
@@ -3,8 +3,22 @@ import IssueListFilterDropDowns from '@/components/IssueList/IssueListFilterDrop
 import { $ListHeader, $IssueWrapper, $IssueList } from '@/components/IssueList/style';
 import ListItem from './ListItem';
 import mockData from './mockData';
+import { useFilterCondition } from '@/contexts/FilterCondition';
+import { useIssueListData } from '@/hooks/useIssueListData';
+import { IssueStatusType } from '@/types/common';
+import { APIIssueStatusType } from '@/api/type';
+import { IListItem } from './ListItem/type';
+
+const convertIssueTypeToAPIType = (
+  issueStatus?: IssueStatusType
+): APIIssueStatusType | undefined => {
+  if (!issueStatus) return undefined;
+  return issueStatus === 'OPEN' ? 'open' : 'close';
+};
 
 export default function List() {
+  const { status: issueStatus } = useFilterCondition();
+  const { status, data } = useIssueListData(convertIssueTypeToAPIType(issueStatus));
   return (
     <$IssueWrapper>
       <$ListHeader>
@@ -12,8 +26,10 @@ export default function List() {
         <IssueListFilterDropDowns />
       </$ListHeader>
       <$IssueList>
-        {mockData &&
-          mockData.issueList.map(issueData => <ListItem key={issueData.number} {...issueData} />)}
+        {status === 'success' &&
+          data.data.data
+            // .reverse()
+            .map((issueData: IListItem) => <ListItem key={issueData.id} {...issueData} />)}
       </$IssueList>
     </$IssueWrapper>
   );

--- a/FE/src/components/IssueList/mockData.ts
+++ b/FE/src/components/IssueList/mockData.ts
@@ -4,56 +4,163 @@ const mockData: MockData = {
   issueList: [
     {
       title: '이슈 제목',
-      labelList: ['레이블 이름', 'documentation', 'FE'],
-      number: 4,
-      timestamp: '',
-      milestone: '마스터즈 코스',
+      labels: [{ id: 1, name: 'FE', color_code: '#A062cE', description: 'Frontend' }],
+      id: 1,
+      created_at: '',
+      milestone: {
+        id: 1,
+        name: '1주차 개발 스프린트',
+        description: '1주차 개발 스프린트',
+        target_date: '2022-06-30',
+        open_issue: 0,
+        closed_issue: 3,
+        status: 'CLOSE'
+      },
       status: 'OPEN',
       author: {
+        id: 1,
         name: 'anonymous',
-        userId: 'anonymous',
-        profile:
-          'https://images.unsplash.com/profile-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
-      }
+        user_id: 'anonymous',
+        image_url:
+          'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+      },
+      assignees: [
+        {
+          id: 1,
+          name: 'anonymous',
+          user_id: 'anonymous',
+          image_url:
+            'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+        }
+      ]
     },
     {
-      title: '[FE] 이슈 리스트 페이지 레이아웃 구현',
-      labelList: ['FE', 'design'],
-      number: 3,
-      timestamp: '',
-      milestone: '마스터즈 코스',
+      title: '이슈 제목',
+      labels: [{ id: 1, name: 'FE', color_code: '#A062cE', description: 'Frontend' }],
+      id: 2,
+      created_at: '',
+      milestone: {
+        id: 1,
+        name: '1주차 개발 스프린트',
+        description: '1주차 개발 스프린트',
+        target_date: '2022-06-30',
+        open_issue: 0,
+        closed_issue: 3,
+        status: 'CLOSE'
+      },
       status: 'OPEN',
       author: {
-        name: 'Hemdi',
-        userId: 'Hemudi',
-        profile: 'https://avatars.githubusercontent.com/u/34249911?v=4'
-      }
+        id: 1,
+        name: 'anonymous',
+        user_id: 'anonymous',
+        image_url:
+          'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+      },
+      assignees: [
+        {
+          id: 1,
+          name: 'anonymous',
+          user_id: 'anonymous',
+          image_url:
+            'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+        }
+      ]
     },
     {
-      title: '[FE] TextInput 컴포넌트 글자수 체크 기능 구현',
-      labelList: ['FE', 'feature'],
-      number: 2,
-      timestamp: '',
-      milestone: '마스터즈 코스',
+      title: '이슈 제목',
+      labels: [{ id: 1, name: 'FE', color_code: '#A062cE', description: 'Frontend' }],
+      id: 3,
+      created_at: '',
+      milestone: {
+        id: 1,
+        name: '1주차 개발 스프린트',
+        description: '1주차 개발 스프린트',
+        target_date: '2022-06-30',
+        open_issue: 0,
+        closed_issue: 3,
+        status: 'CLOSE'
+      },
       status: 'OPEN',
       author: {
-        name: 'Dony',
-        userId: 'jindonyy',
-        profile: 'https://avatars.githubusercontent.com/u/17706346?v=4'
-      }
+        id: 1,
+        name: 'anonymous',
+        user_id: 'anonymous',
+        image_url:
+          'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+      },
+      assignees: [
+        {
+          id: 1,
+          name: 'anonymous',
+          user_id: 'anonymous',
+          image_url:
+            'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+        }
+      ]
     },
     {
-      title: '[BE] GitHub과의 OAuth 통신 구현',
-      labelList: ['BE', 'feature'],
-      number: 1,
-      timestamp: '',
-      milestone: '마스터즈 코스',
-      status: 'CLOSE',
+      title: '이슈 제목',
+      labels: [{ id: 1, name: 'FE', color_code: '#A062cE', description: 'Frontend' }],
+      id: 5,
+      created_at: '',
+      milestone: {
+        id: 1,
+        name: '1주차 개발 스프린트',
+        description: '1주차 개발 스프린트',
+        target_date: '2022-06-30',
+        open_issue: 0,
+        closed_issue: 3,
+        status: 'CLOSE'
+      },
+      status: 'OPEN',
       author: {
-        name: 'Sammy',
-        userId: 'astraum',
-        profile: 'https://avatars.githubusercontent.com/u/94687862?v=4'
-      }
+        id: 1,
+        name: 'anonymous',
+        user_id: 'anonymous',
+        image_url:
+          'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+      },
+      assignees: [
+        {
+          id: 1,
+          name: 'anonymous',
+          user_id: 'anonymous',
+          image_url:
+            'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+        }
+      ]
+    },
+    {
+      title: '이슈 제목',
+      labels: [{ id: 1, name: 'FE', color_code: '#A062cE', description: 'Frontend' }],
+      id: 4,
+      created_at: '',
+      milestone: {
+        id: 1,
+        name: '1주차 개발 스프린트',
+        description: '1주차 개발 스프린트',
+        target_date: '2022-06-30',
+        open_issue: 0,
+        closed_issue: 3,
+        status: 'CLOSE'
+      },
+      status: 'OPEN',
+      author: {
+        id: 1,
+        name: 'anonymous',
+        user_id: 'anonymous',
+        image_url:
+          'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+      },
+      assignees: [
+        {
+          id: 1,
+          name: 'anonymous',
+          user_id: 'anonymous',
+          image_url:
+            'https://images.unsplash.com/image_url-fb-1620954106-6ea0901e5361.jpg?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128'
+        }
+      ]
     }
   ],
   labelList: [
@@ -73,11 +180,30 @@ const mockData: MockData = {
   milestoneList: [
     {
       id: 1,
-      name: '첫번째 마일스톤',
-      description: '마일스톤 마일스톤 첫첫 마일스톤',
+      name: '1주차 개발 스프린트',
+      description: '1주차 개발 스프린트',
+      target_date: '2022-06-30',
+      open_issue: 0,
+      closed_issue: 3,
+      status: 'CLOSE'
+    },
+    {
+      id: 2,
+      name: '2주차 개발 스프린트',
+      description: '2주차 개발 스프린트',
       target_date: '2022-06-30',
       open_issue: 1,
-      closed_issue: 1
+      closed_issue: 3,
+      status: 'CLOSE'
+    },
+    {
+      id: 3,
+      name: '3주차 개발 스프린트',
+      description: '3주차 개발 스프린트',
+      target_date: '2022-06-30',
+      open_issue: 2,
+      closed_issue: 2,
+      status: 'OPEN'
     }
   ]
 };

--- a/FE/src/components/IssueList/style.ts
+++ b/FE/src/components/IssueList/style.ts
@@ -4,16 +4,15 @@ const $ListHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
   height: 65px;
   padding: 0 30px;
   background-color: ${({ theme }) => theme.COLOR.background};
   border-bottom: 1px solid ${({ theme }) => theme.COLOR.line};
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
 `;
 
 const $IssueWrapper = styled.div`
-  width: 100%;
-  overflow: hidden;
   border-radius: 16px;
   border: 1px solid ${({ theme }) => theme.COLOR.line};
   background-color: ${({ theme }) => theme.PALETTE.WHITE};

--- a/FE/src/components/common/Dropdown/Panel/index.tsx
+++ b/FE/src/components/common/Dropdown/Panel/index.tsx
@@ -6,7 +6,10 @@ import {
   $SelectList,
   $SelectedItem
 } from '@/components/common/Dropdown/Panel/style';
+import { IFilterCondition } from '@/types/common';
 import { IPanelProps } from '@/components/common/Dropdown/Panel/type';
+import { setCondition } from '@/contexts/FilterCondition/action';
+import { useFilterConditionDispatch } from '@/contexts/FilterCondition';
 
 export default function Panel({
   panelRef,
@@ -17,9 +20,15 @@ export default function Panel({
   hidePanel,
   ...props
 }: IPanelProps) {
-  const handleSelectedItemClick = (value: string) => {
+  const dispatch = useFilterConditionDispatch();
+
+  const handleSelectedItemClick = (value: string, filterCondition?: IFilterCondition) => {
     updateSelectedValue(value);
     hidePanel();
+
+    if (filterCondition) {
+      setCondition(dispatch, filterCondition);
+    }
   };
 
   return (
@@ -31,12 +40,12 @@ export default function Panel({
         ))}
       </$Select>
       <$SelectList>
-        {options.map(({ children, radio, value }) => (
+        {options.map(({ children, radio, value, filterCondition }) => (
           <$SelectedItem
             key={value}
             id={value}
             selected={value === selectedValue}
-            onMouseUp={() => handleSelectedItemClick(value)}
+            onMouseUp={() => handleSelectedItemClick(value, filterCondition)}
           >
             {children}
             {value === selectedValue ? radio?.on : radio?.off}

--- a/FE/src/components/common/Dropdown/Panel/type.ts
+++ b/FE/src/components/common/Dropdown/Panel/type.ts
@@ -1,3 +1,4 @@
+import { IFilterCondition } from '@/types/common';
 import React from 'react';
 
 type Left = 'left' | 'right';
@@ -6,6 +7,7 @@ type Option = {
   children: React.ReactNode | string;
   radio?: { on: React.ReactNode; off: React.ReactNode };
   value: string;
+  filterCondition?: IFilterCondition;
 };
 
 interface I$PanelProps {

--- a/FE/src/components/common/Dropdown/type.ts
+++ b/FE/src/components/common/Dropdown/type.ts
@@ -5,7 +5,7 @@ interface IDropDown extends I$PanelProps {
   indicatorGap?: string;
   indicatorPadding?: string;
   panelName: string;
-  options: Option[];
+  options: Option[] | [];
   initialValue?: string;
 }
 

--- a/FE/src/components/common/Label/index.tsx
+++ b/FE/src/components/common/Label/index.tsx
@@ -1,9 +1,9 @@
 import { $Label } from '@/components/common/Label/style';
 import { ILabelProps } from '@/components/common/Label/type';
 
-export default function Label({ children, size = 'large', status }: ILabelProps) {
+export default function Label({ children, size = 'large', status, background }: ILabelProps) {
   return (
-    <$Label size={size} status={status}>
+    <$Label size={size} status={status} background={background}>
       {children}
     </$Label>
   );

--- a/FE/src/components/common/Label/style.ts
+++ b/FE/src/components/common/Label/style.ts
@@ -23,11 +23,12 @@ const getSizeStyle = (size: Size) => {
 const $Label = styled.span<ILabelProps>`
   display: flex;
   align-items: center;
-  width: fit-content;
+  min-width: fit-content;
   padding: 0 16px;
   font-size: ${({ theme }) => theme.FONT.SIZE.X_SMALL};
   color: ${({ theme, status }) => theme.LABEL[status].color};
-  background: ${({ theme, status }) => theme.LABEL[status].background};
+  background: ${({ theme, status, background }) =>
+    background ? background : theme.LABEL[status].background};
   border: ${({ theme, status }) =>
     theme.LABEL[status].border ? `1px solid ${theme.LABEL[status].border}` : 0};
   svg {

--- a/FE/src/components/common/Label/type.ts
+++ b/FE/src/components/common/Label/type.ts
@@ -8,6 +8,7 @@ interface ILabelProps {
   children: React.ReactNode | string;
   size?: Size;
   status: Status;
+  background: string;
 }
 
 export type { Size, Status, ILabelProps };

--- a/FE/src/components/common/TextInput/style.ts
+++ b/FE/src/components/common/TextInput/style.ts
@@ -117,6 +117,7 @@ const createCustomEventStyle = (
 
 const $TextInputWrap = styled.div`
   position: relative;
+  width: 100%;
 `;
 
 const $Label = styled.label<I$Label>`

--- a/FE/src/contexts/FilterCondition/action.ts
+++ b/FE/src/contexts/FilterCondition/action.ts
@@ -1,0 +1,29 @@
+import { DispatchType } from '@/contexts/FilterCondition/type';
+
+export const setStatus = (dispatch: DispatchType, status: 'open' | 'close') => {
+  dispatch({ type: 'SET_STATE', payload: { status } });
+};
+
+export const setAssignee = (dispatch: DispatchType, assignee: string) => {
+  dispatch({ type: 'SET_ASSIGNEE', payload: { assignee } });
+};
+
+export const setLabel = (dispatch: DispatchType, label: string) => {
+  dispatch({ type: 'SET_LABEL', payload: { label } });
+};
+
+export const setMilestone = (dispatch: DispatchType, milestone: string) => {
+  dispatch({ type: 'SET_MILESTONE', payload: { milestone } });
+};
+
+export const setAuthor = (dispatch: DispatchType, author: string) => {
+  dispatch({ type: 'SET_AUTHOR', payload: { author } });
+};
+
+export const setComment = (dispatch: DispatchType, comment: string) => {
+  dispatch({ type: 'SET_COMMENT', payload: { comment } });
+};
+
+export const reset = (dispatch: DispatchType) => {
+  dispatch({ type: 'RESET', payload: {} });
+};

--- a/FE/src/contexts/FilterCondition/action.ts
+++ b/FE/src/contexts/FilterCondition/action.ts
@@ -1,27 +1,8 @@
 import { DispatchType } from '@/contexts/FilterCondition/type';
+import { IFilterCondition } from '@/types/common';
 
-export const setStatus = (dispatch: DispatchType, status: 'open' | 'close') => {
-  dispatch({ type: 'SET_STATE', payload: { status } });
-};
-
-export const setAssignee = (dispatch: DispatchType, assignee: string) => {
-  dispatch({ type: 'SET_ASSIGNEE', payload: { assignee } });
-};
-
-export const setLabel = (dispatch: DispatchType, label: string) => {
-  dispatch({ type: 'SET_LABEL', payload: { label } });
-};
-
-export const setMilestone = (dispatch: DispatchType, milestone: string) => {
-  dispatch({ type: 'SET_MILESTONE', payload: { milestone } });
-};
-
-export const setAuthor = (dispatch: DispatchType, author: string) => {
-  dispatch({ type: 'SET_AUTHOR', payload: { author } });
-};
-
-export const setComment = (dispatch: DispatchType, comment: string) => {
-  dispatch({ type: 'SET_COMMENT', payload: { comment } });
+export const setCondition = (dispatch: DispatchType, condition: IFilterCondition) => {
+  dispatch({ type: 'SET_CONDITION', payload: { ...condition } });
 };
 
 export const reset = (dispatch: DispatchType) => {

--- a/FE/src/contexts/FilterCondition/index.tsx
+++ b/FE/src/contexts/FilterCondition/index.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useMemo, useReducer } from 'react';
+import { InitFilterCondition, reducer } from '@/contexts/FilterCondition/reducer';
+import { DispatchType } from './type';
+
+const FilterConditionContext = createContext(InitFilterCondition);
+const DispatchContext = createContext<DispatchType | undefined>(undefined);
+
+const useFilterCondition = () => {
+  const context = useContext(FilterConditionContext);
+
+  if (!context) {
+    throw new Error('Filter Condition Context must be used within IssueList');
+  }
+
+  return context;
+};
+
+const useFilterConditionDispatch = () => {
+  const context = useContext(DispatchContext);
+
+  if (!context) {
+    throw new Error('Filter Condition Dispatch Context must be used within IssueList');
+  }
+
+  return context;
+};
+
+function FilterConditionProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, InitFilterCondition);
+
+  return (
+    <DispatchContext.Provider value={dispatch}>
+      <FilterConditionContext.Provider value={state}>{children}</FilterConditionContext.Provider>
+    </DispatchContext.Provider>
+  );
+}
+
+export { useFilterCondition, useFilterConditionDispatch, FilterConditionProvider };

--- a/FE/src/contexts/FilterCondition/reducer.ts
+++ b/FE/src/contexts/FilterCondition/reducer.ts
@@ -1,0 +1,38 @@
+import { IFilterCondition, Action, ActionType } from '@/contexts/FilterCondition/type';
+
+const InitFilterCondition: IFilterCondition = {
+  status: 'open',
+  assignee: null,
+  label: null,
+  milestone: null,
+  author: null,
+  comment: null
+};
+
+function reducer(
+  state: IFilterCondition,
+  action: Action<ActionType, IFilterCondition>
+): IFilterCondition {
+  const { type, payload } = action;
+
+  switch (type) {
+    case 'SET_STATE':
+      return { ...state, status: payload.status };
+    case 'SET_ASSIGNEE':
+      return { ...state, assignee: payload.assignee };
+    case 'SET_LABEL':
+      return { ...state, label: payload.label };
+    case 'SET_MILESTONE':
+      return { ...state, milestone: payload.milestone };
+    case 'SET_AUTHOR':
+      return { ...state, author: payload.author };
+    case 'SET_COMMENT':
+      return { ...state, comment: payload.comment };
+    case 'RESET':
+      return InitFilterCondition;
+    default:
+      return state;
+  }
+}
+
+export { InitFilterCondition, reducer };

--- a/FE/src/contexts/FilterCondition/reducer.ts
+++ b/FE/src/contexts/FilterCondition/reducer.ts
@@ -1,7 +1,8 @@
-import { IFilterCondition, Action, ActionType } from '@/contexts/FilterCondition/type';
+import { Action, ActionType } from '@/contexts/FilterCondition/type';
+import { IFilterCondition } from '@/types/common';
 
 const InitFilterCondition: IFilterCondition = {
-  status: 'open',
+  status: 'OPEN',
   assignee: null,
   label: null,
   milestone: null,
@@ -16,18 +17,8 @@ function reducer(
   const { type, payload } = action;
 
   switch (type) {
-    case 'SET_STATE':
-      return { ...state, status: payload.status };
-    case 'SET_ASSIGNEE':
-      return { ...state, assignee: payload.assignee };
-    case 'SET_LABEL':
-      return { ...state, label: payload.label };
-    case 'SET_MILESTONE':
-      return { ...state, milestone: payload.milestone };
-    case 'SET_AUTHOR':
-      return { ...state, author: payload.author };
-    case 'SET_COMMENT':
-      return { ...state, comment: payload.comment };
+    case 'SET_CONDITION':
+      return { ...state, ...payload };
     case 'RESET':
       return InitFilterCondition;
     default:
@@ -35,4 +26,23 @@ function reducer(
   }
 }
 
-export { InitFilterCondition, reducer };
+function createFilterConditionString({
+  status,
+  assignee,
+  author,
+  label,
+  milestone,
+  comment
+}: IFilterCondition) {
+  return (
+    `is:${status?.toLowerCase()}` +
+    ` is:issue` +
+    (assignee ? ` assignee:${assignee}` : '') +
+    (author ? ` author:${author}` : '') +
+    (label ? ` label:${label}` : '') +
+    (milestone ? ` milestone:${milestone}` : '') +
+    (comment ? ` comment:${comment}` : '')
+  );
+}
+
+export { InitFilterCondition, reducer, createFilterConditionString };

--- a/FE/src/contexts/FilterCondition/type.ts
+++ b/FE/src/contexts/FilterCondition/type.ts
@@ -1,11 +1,4 @@
-interface IFilterCondition {
-  status?: 'open' | 'close';
-  assignee?: string | null;
-  label?: string | null;
-  milestone?: string | null;
-  author?: string | null;
-  comment?: string | null;
-}
+import { IFilterCondition } from '@/types/common';
 
 interface Action<T, P> {
   readonly type: T;
@@ -14,13 +7,6 @@ interface Action<T, P> {
 
 type DispatchType = React.Dispatch<Action<ActionType, IFilterCondition>>;
 
-type ActionType =
-  | 'SET_STATE'
-  | 'SET_ASSIGNEE'
-  | 'SET_LABEL'
-  | 'SET_MILESTONE'
-  | 'SET_AUTHOR'
-  | 'SET_COMMENT'
-  | 'RESET';
+type ActionType = 'SET_CONDITION' | 'RESET';
 
 export type { IFilterCondition, Action, DispatchType, ActionType };

--- a/FE/src/contexts/FilterCondition/type.ts
+++ b/FE/src/contexts/FilterCondition/type.ts
@@ -1,0 +1,26 @@
+interface IFilterCondition {
+  status?: 'open' | 'close';
+  assignee?: string | null;
+  label?: string | null;
+  milestone?: string | null;
+  author?: string | null;
+  comment?: string | null;
+}
+
+interface Action<T, P> {
+  readonly type: T;
+  readonly payload: P;
+}
+
+type DispatchType = React.Dispatch<Action<ActionType, IFilterCondition>>;
+
+type ActionType =
+  | 'SET_STATE'
+  | 'SET_ASSIGNEE'
+  | 'SET_LABEL'
+  | 'SET_MILESTONE'
+  | 'SET_AUTHOR'
+  | 'SET_COMMENT'
+  | 'RESET';
+
+export type { IFilterCondition, Action, DispatchType, ActionType };

--- a/FE/src/hooks/useIssueListData.tsx
+++ b/FE/src/hooks/useIssueListData.tsx
@@ -1,29 +1,26 @@
-import { getIssueCount } from '@/api/issueList';
 import { getIssueList } from '@/api/issueList';
+import { getIssueCount } from '@/api/issueList';
 import { IssueStateType } from '@/api/type';
 import { useQuery } from 'react-query';
 import { AxiosError } from 'axios';
+import { issueListQueryKeys, issueCountQueryKeys } from '@/api/queryKeys';
 
-function useIssueListData(state: IssueStateType = 'open') {
-  return useQuery(['issueList', { status: 'open' }], () => getIssueList(state), {
-    onSuccess: data => {
-      console.log(data);
-    },
-    onError: (e: AxiosError) => {
-      console.log(e.message);
-    }
+const printError = (error: AxiosError) => {
+  console.error(error.message);
+};
+
+function useIssueListData(status?: IssueStateType) {
+  return useQuery(issueListQueryKeys[status ? status : 'all'], () => getIssueList(status), {
+    onSuccess: data => {},
+    onError: printError
   });
 }
 
-function useIssueListCountData(state: IssueStateType = 'open') {
-  return useQuery(['issueList', { status: 'open' }, 'count'], () => getIssueCount(state), {
-    onSuccess: data => {
-      console.log(state + ' _ ' + data);
-    },
-    onError: (e: AxiosError) => {
-      console.log(e.message);
-    }
+function useIssueCountData(status?: IssueStateType) {
+  return useQuery(issueCountQueryKeys[status ? status : 'all'], () => getIssueCount(status), {
+    onSuccess: data => {},
+    onError: printError
   });
 }
 
-export { useIssueListData, useIssueListCountData };
+export { useIssueListData, useIssueCountData };

--- a/FE/src/hooks/useIssueListData.tsx
+++ b/FE/src/hooks/useIssueListData.tsx
@@ -1,0 +1,29 @@
+import { getIssueCount } from '@/api/issueList';
+import { getIssueList } from '@/api/issueList';
+import { IssueStateType } from '@/api/type';
+import { useQuery } from 'react-query';
+import { AxiosError } from 'axios';
+
+function useIssueListData(state: IssueStateType = 'open') {
+  return useQuery(['issueList', { status: 'open' }], () => getIssueList(state), {
+    onSuccess: data => {
+      console.log(data);
+    },
+    onError: (e: AxiosError) => {
+      console.log(e.message);
+    }
+  });
+}
+
+function useIssueListCountData(state: IssueStateType = 'open') {
+  return useQuery(['issueList', { status: 'open' }, 'count'], () => getIssueCount(state), {
+    onSuccess: data => {
+      console.log(state + ' _ ' + data);
+    },
+    onError: (e: AxiosError) => {
+      console.log(e.message);
+    }
+  });
+}
+
+export { useIssueListData, useIssueListCountData };

--- a/FE/src/hooks/useIssueListData.tsx
+++ b/FE/src/hooks/useIssueListData.tsx
@@ -1,6 +1,6 @@
 import { getIssueList } from '@/api/issueList';
 import { getIssueCount } from '@/api/issueList';
-import { IssueStateType } from '@/api/type';
+import { APIIssueStatusType } from '@/api/type';
 import { useQuery } from 'react-query';
 import { AxiosError } from 'axios';
 import { issueListQueryKeys, issueCountQueryKeys } from '@/api/queryKeys';
@@ -9,14 +9,14 @@ const printError = (error: AxiosError) => {
   console.error(error.message);
 };
 
-function useIssueListData(status?: IssueStateType) {
+function useIssueListData(status?: APIIssueStatusType) {
   return useQuery(issueListQueryKeys[status ? status : 'all'], () => getIssueList(status), {
     onSuccess: data => {},
     onError: printError
   });
 }
 
-function useIssueCountData(status?: IssueStateType) {
+function useIssueCountData(status?: APIIssueStatusType) {
   return useQuery(issueCountQueryKeys[status ? status : 'all'], () => getIssueCount(status), {
     onSuccess: data => {},
     onError: printError

--- a/FE/src/hooks/useLabelListData.tsx
+++ b/FE/src/hooks/useLabelListData.tsx
@@ -1,0 +1,25 @@
+import { getLabelList } from '@/api/labels';
+import { getLabelCount } from '@/api/labels';
+import { useQuery } from 'react-query';
+import { AxiosError } from 'axios';
+import { labelListQueryKeys, labelCountQueryKeys } from '@/api/queryKeys';
+
+const printError = (error: AxiosError) => {
+  console.error(error.message);
+};
+
+function useLabelListData() {
+  return useQuery(labelListQueryKeys, () => getLabelList(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+function useLabelCountData() {
+  return useQuery(labelCountQueryKeys, () => getLabelCount(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+export { useLabelListData, useLabelCountData };

--- a/FE/src/hooks/useLabelListData.tsx
+++ b/FE/src/hooks/useLabelListData.tsx
@@ -11,14 +11,18 @@ const printError = (error: AxiosError) => {
 function useLabelListData() {
   return useQuery(labelListQueryKeys, () => getLabelList(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 
 function useLabelCountData() {
   return useQuery(labelCountQueryKeys, () => getLabelCount(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 

--- a/FE/src/hooks/useMemberListData.tsx
+++ b/FE/src/hooks/useMemberListData.tsx
@@ -1,0 +1,25 @@
+import { getMemberList } from '@/api/members';
+import { getCurrentMember } from '@/api/members';
+import { useQuery } from 'react-query';
+import { AxiosError } from 'axios';
+import { memberListQueryKeys, currentMemberQueryKeys } from '@/api/queryKeys';
+
+const printError = (error: AxiosError) => {
+  console.error(error.message);
+};
+
+function useMemberListData() {
+  return useQuery(memberListQueryKeys, () => getMemberList(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+function useMemberCountData() {
+  return useQuery(currentMemberQueryKeys, () => getCurrentMember(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+export { useMemberListData, useMemberCountData };

--- a/FE/src/hooks/useMemberListData.tsx
+++ b/FE/src/hooks/useMemberListData.tsx
@@ -11,14 +11,18 @@ const printError = (error: AxiosError) => {
 function useMemberListData() {
   return useQuery(memberListQueryKeys, () => getMemberList(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 
 function useMemberCountData() {
   return useQuery(currentMemberQueryKeys, () => getCurrentMember(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 

--- a/FE/src/hooks/useMilestoneListData.tsx
+++ b/FE/src/hooks/useMilestoneListData.tsx
@@ -1,0 +1,25 @@
+import { getMilestoneList } from '@/api/milestones';
+import { getMilestoneCount } from '@/api/milestones';
+import { useQuery } from 'react-query';
+import { AxiosError } from 'axios';
+import { milestoneListQueryKeys, milestoneCountQueryKeys } from '@/api/queryKeys';
+
+const printError = (error: AxiosError) => {
+  console.error(error.message);
+};
+
+function useMilestoneListData() {
+  return useQuery(milestoneListQueryKeys, () => getMilestoneList(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+function useMilestoneCountData() {
+  return useQuery(milestoneCountQueryKeys, () => getMilestoneCount(), {
+    onSuccess: data => {},
+    onError: printError
+  });
+}
+
+export { useMilestoneListData, useMilestoneCountData };

--- a/FE/src/hooks/useMilestoneListData.tsx
+++ b/FE/src/hooks/useMilestoneListData.tsx
@@ -11,14 +11,18 @@ const printError = (error: AxiosError) => {
 function useMilestoneListData() {
   return useQuery(milestoneListQueryKeys, () => getMilestoneList(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 
 function useMilestoneCountData() {
   return useQuery(milestoneCountQueryKeys, () => getMilestoneCount(), {
     onSuccess: data => {},
-    onError: printError
+    onError: printError,
+    staleTime: Infinity,
+    cacheTime: Infinity
   });
 }
 

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -5,15 +5,22 @@ import * as CommonStyle from '@/styles/common';
 
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
 const container = document.getElementById('root');
 const root = createRoot(container as Element);
 
+const queryClient = new QueryClient();
+
 root.render(
-  <ThemeProvider theme={CommonStyle}>
-    <GlobalStyle />
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </ThemeProvider>
+  <QueryClientProvider client={queryClient}>
+    <ReactQueryDevtools initialIsOpen={true} />
+    <ThemeProvider theme={CommonStyle}>
+      <GlobalStyle />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
+  </QueryClientProvider>
 );

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -11,7 +11,13 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 const container = document.getElementById('root');
 const root = createRoot(container as Element);
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false
+    }
+  }
+});
 
 root.render(
   <QueryClientProvider client={queryClient}>

--- a/FE/src/layout/index.tsx
+++ b/FE/src/layout/index.tsx
@@ -11,7 +11,7 @@ function Layout({ header, children, footer, ...props }: LayoutProps) {
     <Wrapper {...props}>
       {header && <Header>{header}</Header>}
       <Contents>{children}</Contents>
-      {footer && <Footer>{footer}</Footer>}
+      <Footer>{footer}</Footer>
     </Wrapper>
   );
 }

--- a/FE/src/layout/style.ts
+++ b/FE/src/layout/style.ts
@@ -18,6 +18,8 @@ const Contents = styled.main`
   padding: 0 80px;
 `;
 
-const Footer = styled.footer``;
+const Footer = styled.footer`
+  height: 120px;
+`;
 
 export { Wrapper, Header, Contents, Footer };

--- a/FE/src/pages/IssueList/filterBarOptionData.tsx
+++ b/FE/src/pages/IssueList/filterBarOptionData.tsx
@@ -1,0 +1,81 @@
+import { Icon } from '@/components/common/Icon';
+import { getCurrentUserInfoOf } from '@/utils/user';
+import { Option } from '@/components/common/Dropdown/Panel/type';
+
+const radioIcon = {
+  off: <Icon iconType="radioOff" />,
+  on: <Icon iconType="radioOn" />
+};
+
+const FILTER_BAR_OPTIONS = ((): Option[] => {
+  const currentUserId = getCurrentUserInfoOf('user_id') as string;
+  return [
+    {
+      children: '열린 이슈',
+      radio: radioIcon,
+      value: 'opened',
+      filterCondition: {
+        status: 'OPEN',
+        assignee: null,
+        label: null,
+        milestone: null,
+        author: null,
+        comment: null
+      }
+    },
+    {
+      children: '내가 작성한 이슈',
+      radio: radioIcon,
+      value: 'written',
+      filterCondition: {
+        status: 'OPEN',
+        author: currentUserId,
+        assignee: null,
+        label: null,
+        milestone: null,
+        comment: null
+      }
+    },
+    {
+      children: '나에게 할당된 이슈',
+      radio: radioIcon,
+      value: 'assigned',
+      filterCondition: {
+        status: 'OPEN',
+        assignee: currentUserId,
+        label: null,
+        milestone: null,
+        author: null,
+        comment: null
+      }
+    },
+    {
+      children: '내가 댓글을 남긴 이슈',
+      radio: radioIcon,
+      value: 'comments',
+      filterCondition: {
+        status: 'OPEN',
+        comment: currentUserId,
+        assignee: null,
+        label: null,
+        milestone: null,
+        author: null
+      }
+    },
+    {
+      children: '닫힌 이슈',
+      radio: radioIcon,
+      value: 'closed',
+      filterCondition: {
+        status: 'CLOSE',
+        assignee: null,
+        label: null,
+        milestone: null,
+        author: null,
+        comment: null
+      }
+    }
+  ];
+})();
+
+export { FILTER_BAR_OPTIONS };

--- a/FE/src/pages/IssueList/index.tsx
+++ b/FE/src/pages/IssueList/index.tsx
@@ -7,19 +7,8 @@ import Tabs from '@/components/common/Tabs';
 import { listItem } from '@/components/common/Tabs/type';
 import Layout from '@/layout';
 import { $MenuWrapper, $ButtonWrapper } from '@/pages/IssueList/style';
-
-const tabItems: listItem[] = [
-  {
-    name: '레이블',
-    iconType: 'label',
-    count: 100
-  },
-  {
-    name: '마일스톤',
-    iconType: 'milestone',
-    count: 10
-  }
-];
+import { useLabelCountData } from '@/hooks/useLabelListData';
+import { useMilestoneCountData } from '@/hooks/useMilestoneListData';
 
 const radioIcon = {
   off: <Icon iconType="radioOff" />,
@@ -63,6 +52,22 @@ const filterBarProps = {
 };
 
 export default function IssueListPage() {
+  const { status: labelDataStatus, data: labelCount } = useLabelCountData();
+  const { status: milestoneDataStatus, data: milestoneCount } = useMilestoneCountData();
+
+  const tabItems: listItem[] = [
+    {
+      name: '레이블',
+      iconType: 'label',
+      count: labelCount?.data.total_count
+    },
+    {
+      name: '마일스톤',
+      iconType: 'milestone',
+      count: milestoneCount?.data.total_count
+    }
+  ];
+
   return (
     <Layout header={<Header />}>
       <$MenuWrapper>

--- a/FE/src/pages/IssueList/index.tsx
+++ b/FE/src/pages/IssueList/index.tsx
@@ -7,6 +7,9 @@ import Tabs from '@/components/common/Tabs';
 import { listItem } from '@/components/common/Tabs/type';
 import Layout from '@/layout';
 import { $MenuWrapper, $ButtonWrapper } from '@/pages/IssueList/style';
+import { FilterConditionProvider } from '@/contexts/FilterCondition';
+import { FILTER_BAR_OPTIONS } from './filterBarOptionData';
+import { IFilterBarProps } from '@/components/IssueList/FilterBar/type';
 
 const tabItems: listItem[] = [
   {
@@ -26,36 +29,10 @@ const radioIcon = {
   on: <Icon iconType="radioOn" />
 };
 
-const filterBarProps = {
+const filterBarProps: IFilterBarProps = {
   indicatorName: '필터',
   panelName: '이슈 필터',
-  options: [
-    {
-      children: '열린 이슈',
-      radio: radioIcon,
-      value: 'opened'
-    },
-    {
-      children: '내가 작성한 이슈',
-      radio: radioIcon,
-      value: 'written'
-    },
-    {
-      children: '나에게 할당된 이슈',
-      radio: radioIcon,
-      value: 'assigned'
-    },
-    {
-      children: '내가 댓글을 남긴 이슈',
-      radio: radioIcon,
-      value: 'comments'
-    },
-    {
-      children: '닫힌 이슈',
-      radio: radioIcon,
-      value: 'closed'
-    }
-  ],
+  options: FILTER_BAR_OPTIONS,
   initialValue: 'opened',
   inputStyleType: 'small',
   placeholder: 'is:issue is:open',
@@ -65,17 +42,19 @@ const filterBarProps = {
 export default function IssueListPage() {
   return (
     <Layout header={<Header />}>
-      <$MenuWrapper>
-        <FilterBar {...filterBarProps} />
-        <$ButtonWrapper>
-          <Tabs list={tabItems} />
-          <Button styleType="smallStandard">
-            <Icon iconType="plus" />
-            이슈 작성
-          </Button>
-        </$ButtonWrapper>
-      </$MenuWrapper>
-      <IssueList />
+      <FilterConditionProvider>
+        <$MenuWrapper>
+          <FilterBar {...filterBarProps} />
+          <$ButtonWrapper>
+            <Tabs list={tabItems} />
+            <Button styleType="smallStandard">
+              <Icon iconType="plus" />
+              이슈 작성
+            </Button>
+          </$ButtonWrapper>
+        </$MenuWrapper>
+        <IssueList />
+      </FilterConditionProvider>
     </Layout>
   );
 }

--- a/FE/src/pages/Loading/index.tsx
+++ b/FE/src/pages/Loading/index.tsx
@@ -16,7 +16,7 @@ export default function Loading() {
       ignoreQueryPrefix: true
     });
 
-    const response = await getLoginToken({ code: code });
+    const response = await getLoginToken(code + '');
     const { data, status } = response;
 
     if (status !== 200) {
@@ -25,6 +25,7 @@ export default function Loading() {
 
     const { current_user, login_token } = data;
     localStorage.setItem('currentUserInfo', JSON.stringify(current_user));
+    localStorage.setItem('currentUserToken', login_token);
     navigate('/issue-list', { replace: true });
   };
 

--- a/FE/src/types/common.ts
+++ b/FE/src/types/common.ts
@@ -1,0 +1,10 @@
+export type IssueStatusType = 'OPEN' | 'CLOSE';
+
+export interface IFilterCondition {
+  status?: IssueStatusType;
+  assignee?: string | null;
+  label?: string | null;
+  milestone?: string | null;
+  author?: string | null;
+  comment?: string | null;
+}

--- a/FE/src/utils/user.ts
+++ b/FE/src/utils/user.ts
@@ -1,0 +1,23 @@
+import { IMember } from '@/components/IssueList/ListItem/type';
+
+const getCurrentUserInfo = () => {
+  const currentUserInfo = localStorage.getItem('currentUserInfo');
+
+  if (!currentUserInfo) return;
+
+  const userInfoObject: IMember = JSON.parse(currentUserInfo);
+
+  return userInfoObject;
+};
+
+const getCurrentUserInfoOf = (infoType: keyof IMember) => {
+  const userInfoObject = getCurrentUserInfo();
+
+  if (!userInfoObject) return null;
+
+  const { [infoType]: userData } = userInfoObject;
+
+  return userData;
+};
+
+export { getCurrentUserInfo, getCurrentUserInfoOf };


### PR DESCRIPTION
안녕하세요! Goody!
[Dony](https://github.com/jindonyy)와 [Hemdi](https://github.com/hemudi)입니다!
마지막 주가 되어 기능 개발과 리팩토링 중에 고민을 해봤지만 React-Query를 이전부터 사용해보고 싶었어서 마지막 주는 React-Query를 이용한 data fetch 기능 구현을 중점으로 프로젝트를 진행하고자 합니다.
리팩토링은 추후 코드스쿼드가 끝난 이후에도 개발을 진행해볼 예정이라 부채로 남겨두기로 했습니다. 😇
그때 Goody에게 받은 리뷰들 중 아직 반영 못한 것들도 꼭 반영해볼 예정이니 이번 PR에서도 개선이 필요한 부분을 짚어주신다면 감사하겠습니다!
아쉬운 마지막 주, 리뷰 잘 부탁드립니다! 🥹
<br>

## 📋 진행 상황
### 🔨 작업 내역
- [x] https://github.com/jindonyy/issue-tracker/issues/27
- [x] https://github.com/jindonyy/issue-tracker/issues/28
- [x] https://github.com/jindonyy/issue-tracker/issues/26
    - [x] https://github.com/jindonyy/issue-tracker/issues/29
    - [x] https://github.com/jindonyy/issue-tracker/issues/30
    - [ ] https://github.com/jindonyy/issue-tracker/issues/31
    - [x] https://github.com/jindonyy/issue-tracker/issues/32
- [ ] https://github.com/jindonyy/issue-tracker/issues/33
<br>

### 🚛 데이터 fetch
<details>
<summary>레이블, 마일스톤 버튼</summary>
<div markdown="1">
자주 변경이 일어나지 않는 부분이라 최초 렌더 시에만 fetch되도록 설계하였습니다.<br>
때문에 React-Query에서 data를 refetch 하는 옵션인 <b>staleTime</b>과 캐시에 저장되는 시간인 <b>cacheTime</b>을 Infinity로 설정하였습니다.<br>
이렇게 할 경우 페이지 최조 접속 시 cache에 데이터가 저장되고, cacheTime이 Infinity이기 때문에 다른 페이지로 이동 후 다시 돌아오는 시점에도 기존의 캐시 데이터를 사용하여 화면에 그려지게 됩니다.<br>
그럼 cache 데이터가 refresh 되는 시점은 새로고침 할 경우만 입니다.(리액트 쿼리에서 캐시는 새로고침 시에 초기화)<br>
저희는 이슈리스트 페이지에 접속할 때마다 최근의 데이터로 보여졌으면 하여 <b>refetchOnMount</b> 옵션을 사용하여 개선해볼 계획입니다.<br>
현재 데이터 loading 시점에는 레이블과 마일스톤 개수가 보이지 않다 success 되면 개수가 보여집니다.
</div>
</details>
<details>
<summary>filter dropdown</summary>
<div markdown="1">
레이블, 마일스톤 버튼과 fetch 해오는 시점과 옵션은 동일합니다.<br>
현재 data가 loading 시점에는 filter option들이 보여지지 않다 success 되면 option들이 나타나도록 하였습니다. 그러나 사용자가 loading 시점에 dropdown 버튼을 눌렀다가 fetch 되기 전에 dropdown panel을 끈다면 option이 없다고 생각할 수 있을거 같아 로딩 UI를 추가해볼 생각입니다.
</div>
</details>
<details>
<summary>filter bar</summary>
<div markdown="1">
filter bar의 필터 조건을 FilterCondition 이라는 Context를 만들어 Context의 상태가 바뀔 때마다 그에 맞는 issueList를 fetch 해오는 방식으로 구현했습니다.
현재 나온 Mock Api가 아직 open issue, close issue 조건만 설정 할 수 있어서 다른 조건은 설정해도 fetch 해오지는 않습니다!
이후 filter bar의 input 으로 직접 옵션을 입력 하여 fetch 받는 기능도 구현해볼 예정입니다.
</div>
</details>
<details>
<summary>issueList</summary>
<div markdown="1">
issue list는 자주 바뀌기 때문에 열린 이슈, 닫힌 이슈 탭을 클릭할 때마다 fetch해오도록 설계하였습니다.<br>
때문에 <b>staleTime</b>과 <b>cacheTime</b>은 default 값인 0과 5분으로 그대로 두었습니다. staleTime이 0일 경우 fetch해온 데이터가 항상 stale(오래된) 데이터라고 여기기 때문에 refetch의 조건을 만족할 시 항상 refetch 해오게 됩니다.<br>
refetch 조건 중 하나인 useQuery에 key로 state를 사용하여 state가 변경될 때마다 refetch하게 됩니다.<br>
issue list도 마찬가지로 loading 시 issue list item이 보여지지 않다가 success 되면 item들이 보여집니다. 해당 부분도 loading 컴포넌트를 추가해볼 생각입니다.
</div>
</details>
<br>
<br>

## 🎥 구현 결과

https://user-images.githubusercontent.com/17706346/176545858-b49187af-e7b1-43fc-a0d8-742cf7ddbfa8.mov


<br>
<br>

## 🤔 질문
### 🔘 Button Props
지난 주 두번째 PR에서 남겨주셨던 [Button의 Style 관련 prop 리뷰](https://github.com/codesquad-members-2022/issue-tracker/pull/202#discussion_r906656009)에 대해 어떻게 하면 좋을지 고민을 해봤습니다!
해당 버튼 컴포넌트를 설계 할 때의 방향이 styleType prop으로 미리 정의 된 스타일 속성값들을 뭉텅이로 적용하면서 동시에 background만 바뀐다던가 border 값만 바뀐다던가 하는 작은 스타일 변화에 유연하게 대응하기 위해 optinal한 style prop들을 추가해줬습니다.
최대한 이번 이슈 트래커에서 나오는 모든 버튼들은 이 버튼 컴포넌트를 재사용 할 수 있게 구현해보고 싶었는데 그러다보니 점점 style 관련 prop들이 늘어나게 되었습니다.
저희가 볼 때도 스타일과 관련된 prop이 많아 상태와 관련된 prop이 잘 보이도록 분리하면 좋을거 같다고 생각했습니다.
그래서 어떻게하면 가독성을 높일 수 있을지 또는 prop을 줄일 수 있을지 고민을 해본 결과 아래의 방법들을 생각해봤습니다.

#### 1. style 관련 속성을 외부에 정의하기
```typescript
const buttonStyle = {
    width: 20px;
    height: 20px;
    ...
};

return (
    <Button {...buttonStyle}></Button>
);
```

외부에 객체로 정의하여 스프레드 연산자로 넘겨주면 prop을 줄이지는 않지만 버튼 태그 자체의 가독성은 높아지는거 같습니다! 뭔가 조삼모사 같네요...ㅎ_ㅎ;

#### 2. style 관련 속성을 하나의 prop으로 받기
```typescript
const buttonStyle = {
    width: 20px;
    height: 20px;
    ...
}

return {
    <StyledButton styles={buttonStyle}></Button>
}

// styled-component를 사용하고 있다면 통채로 style 적용 가능
const StyledButton = styled.Button`
    ${({styles})} => styles}
`;
```

컴포넌트의 style 관련 속성들을 styles라는 prop으로 객체 형태로 통채로 받는 방법입니다.
위의 1번과 달리 실질적인 prop의 수가 줄고 스프레드 연산자를 사용하지 않아 좀 더 가독성이 향상된거 같습니다.
다만 HTML 태그의 style을 inline으로 적용해주는 듯한 느낌이 들어 살짝 괜찮은 방법인지 의문이 듭니다.
또한 중복되는 스타일의 경우 어디에 buttonStyle들을 정의해두고 있어야 할지도 고민해야 하고 Button 태그만을 봤을때 한번에 이게 어떤 스타일의 버튼인지 파악하기 힘들다는 단점이 있는거 같습니다.

#### 3. 추가 되는 스타일에 따라 새로운 Button styleType 추가
```typescript
const buttonStyle: ButtonStyle = {
  large: large,
  smallStandard: smallStandard,
  mediumStandard: mediumStandard,
  smallSecondary: smallSecondary,
  mediumText: mediumText,
  smallText: smallText,
  newStyle: newStyle
};

const newStyle = css`
  color: ${({ theme }) => theme.PALETTE.WHITE};
  background: ${({ theme }) => theme.COLOR.primary.initial};
`;

const StyledButton = styled.Button`
  ${({styleType}) => ${styleType && buttonStyle[styleType]}};
`;

// 사용 할 때
<StyleButton style="newStyle"/>

```
props가 점점 늘어나는 원인은 Button의 재사용성을 높이기 위해 style 관련 속성을 하나하나 추가하기 때문이었습니다.
그래서 재사용성과 범용성은 살짝 내려놓고 2번 방식과 같이 style 관련 prop은 styleType 하나로 줄이는 대신 외부에서 스타일을 정의해서 넣어주는게 아니라 내부에 type 별로 정의해두고 입력 된 type에 따라 스타일을 적용해주는 방식입니다.
이때 만약 정의 된 style의 규모가 너무 커지면 size나 border 등으로 타입을 조금 더 세분화하는 것도 방법일거 같습니다.
이 경우 단점으로는 새로운 스타일이 추가 될 때마다 새로운 타입을 정의해줘야 하지만 Button 태그를 봤을때 type의 값으로 어떤 스타일의 버튼일지 유추가 가능해 가독성이 좋아보인다는 장점이 있는거 같습니다.

이 외에도 이런 저런 방법들을 고민을 해봤는데 사실 어느게 딱 정답이다 싶은 방법을 찾지 못했습니다.
혹시 Goody께서 생각하시는 방법은 어떤건지 여쭤봐도 될까요?