### PR TITLE
[Team-05] [Lee] 이슈트래커 BE 3주차 2번째: 로그인 로직 세부수정 및 인터셉터 추가, 리뷰 반영 리팩토링

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	implementation 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation group: 'com.google.code.gson', name: 'gson'

--- a/BE/src/main/java/kr/codesquad/issuetraker/config/OauthClientConfiguration.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/config/OauthClientConfiguration.java
@@ -1,39 +1,23 @@
 package kr.codesquad.issuetraker.config;
 
 import kr.codesquad.issuetraker.login.oauth.*;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@RequiredArgsConstructor
 @Configuration
 public class OauthClientConfiguration {
-
-    @Value("${github.client-id}")
-    private String githubClientId;
-    @Value("${github.auth-server-url}")
-    private String githubAuthServerUrl;
-    @Value("${github.resource-server-url}")
-    private String githubResourceServerUrl;
-    @Value("${github.secret-key}")
-    private String githubSecretKey;
-
-    @Value("${kakao.client-id}")
-    private String kakaoClientId;
-    @Value("${kakao.auth-server-url}")
-    private String kakaoAuthServerUrl;
-    @Value("${kakao.resource-server-url}")
-    private String kakaoResourceServerUrl;
-    @Value("${kakao.secret-key}")
-    private String kakaoSecretKey;
-
+    private final OauthProperties githubProperties;
+    private final OauthProperties kakaoProperties;
 
     @Bean
     public OauthClientMapper oauthClientMapper() {
-        GithubOauthClient github = new GithubOauthClient(githubClientId, githubAuthServerUrl, githubResourceServerUrl, githubSecretKey);
-        KakaoOauthClient kakao = new KakaoOauthClient(kakaoClientId, kakaoAuthServerUrl, kakaoResourceServerUrl, kakaoSecretKey);
+        GithubOauthClient github = new GithubOauthClient(githubProperties.getClientId(), githubProperties.getAuthServerUrl(), githubProperties.getResourceServerUrl(), githubProperties.getSecretKey());
+        KakaoOauthClient kakao = new KakaoOauthClient(kakaoProperties.getClientId(), kakaoProperties.getAuthServerUrl(), kakaoProperties.getResourceServerUrl(), kakaoProperties.getSecretKey());
 
         Map<String, OauthClient> clientMap = new HashMap<>();
 

--- a/BE/src/main/java/kr/codesquad/issuetraker/config/OauthPropertiesConfiguration.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/config/OauthPropertiesConfiguration.java
@@ -1,0 +1,27 @@
+package kr.codesquad.issuetraker.config;
+
+import kr.codesquad.issuetraker.login.oauth.OauthProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class OauthPropertiesConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "oauth.github")
+    public OauthProperties githubProperties() {
+        return new OauthProperties();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "oauth.kakao")
+    public OauthProperties kakaoProperties() {
+        return new OauthProperties();
+    }
+}
+
+

--- a/BE/src/main/java/kr/codesquad/issuetraker/config/WebConfig.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/config/WebConfig.java
@@ -1,0 +1,24 @@
+package kr.codesquad.issuetraker.config;
+
+import kr.codesquad.issuetraker.login.LoginInterceptor;
+import kr.codesquad.issuetraker.login.jwt.JwtProvider;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginInterceptor(jwtProvider))
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/register/**", "/login/**");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/LoginController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/LoginController.java
@@ -30,7 +30,7 @@ public class LoginController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<UserRegistrationResponseDto> registerWithPassword(@RequestBody UserRegisterRequestDto requestDto) throws NoSuchAlgorithmException {
+    public ResponseEntity<GeneralResponseDto> registerWithPassword(@RequestBody UserRegisterRequestDto requestDto) throws NoSuchAlgorithmException {
         return ResponseEntity.ok(loginService.registerUserWithPassword(requestDto));
     }
 

--- a/BE/src/main/java/kr/codesquad/issuetraker/controller/UserController.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/controller/UserController.java
@@ -1,0 +1,22 @@
+package kr.codesquad.issuetraker.controller;
+
+import kr.codesquad.issuetraker.dto.UserListResponseDto;
+import kr.codesquad.issuetraker.sevice.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<UserListResponseDto> loadAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/issue/IssueRepository.java
@@ -2,11 +2,9 @@ package kr.codesquad.issuetraker.domain.issue;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface IssueRepository extends JpaRepository<Issue, Long>, IssueRepositoryCustom {
     @Query(value = "SELECT i FROM Issue i where i.isDeleted = FALSE")
     public List<Issue> findAllAvailableIssues();

--- a/BE/src/main/java/kr/codesquad/issuetraker/domain/user/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/domain/user/User.java
@@ -26,4 +26,8 @@ public class User {
         this.password = password;
         this.oauthClientType = oauthClientType;
     }
+
+    public boolean isSamePassword(String password) {
+        return this.password.equals(password);
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/GithubAccessTokenResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/GithubAccessTokenResponseDto.java
@@ -1,0 +1,16 @@
+package kr.codesquad.issuetraker.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+public class GithubAccessTokenResponseDto {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+    private String scope;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/IssueListElementDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/IssueListElementDto.java
@@ -13,6 +13,7 @@ public class IssueListElementDto {
     private String description;
     private String milestoneTitle;
     private Label label;
+    private Boolean isOpened;
 
     public static IssueListElementDto of(Issue issue) {
         return IssueListElementDto.builder()
@@ -21,6 +22,7 @@ public class IssueListElementDto {
                 .description(issue.getDescription())
                 .milestoneTitle(issue.getMilestone().getTitle())
                 .label(issue.getLabel())
+                .isOpened(issue.isOpened())
                 .build();
     }
 

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/KakaoAccessTokenResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/KakaoAccessTokenResponseDto.java
@@ -1,0 +1,12 @@
+package kr.codesquad.issuetraker.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class KakaoAccessTokenResponseDto {
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/UserListElementDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/UserListElementDto.java
@@ -1,0 +1,17 @@
+package kr.codesquad.issuetraker.dto;
+
+import kr.codesquad.issuetraker.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserListElementDto {
+    private Long userId;
+    private String displayName;
+    private String profileImageUrl;
+
+    public static UserListElementDto from(User user) {
+        return new UserListElementDto(user.getId(), user.getDisplayName(), user.getProfileImageUrl());
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/UserListResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/UserListResponseDto.java
@@ -1,0 +1,16 @@
+package kr.codesquad.issuetraker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class UserListResponseDto {
+    private List<UserListElementDto> users;
+
+    public UserListResponseDto(List<UserListElementDto> users) {
+        this.users = new ArrayList<>(users);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/dto/UserRegistrationResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/dto/UserRegistrationResponseDto.java
@@ -1,9 +1,0 @@
-package kr.codesquad.issuetraker.dto;
-
-import kr.codesquad.issuetraker.domain.user.User;
-
-public class UserRegistrationResponseDto {
-    public static UserRegistrationResponseDto of(User user) {
-        return null;
-    }
-}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/ExpiredJwtTokenException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/ExpiredJwtTokenException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class ExpiredJwtTokenException extends JwtException {
+    public ExpiredJwtTokenException() {
+        super("JWT 토큰이 만료되었습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/InvalidJwtTokenException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/InvalidJwtTokenException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class InvalidJwtTokenException extends JwtException {
+    public InvalidJwtTokenException() {
+        super("JWT 인증 토큰이 올바르지 않습니다.");
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/JwtException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/JwtException.java
@@ -1,0 +1,7 @@
+package kr.codesquad.issuetraker.exception;
+
+public class JwtException extends RuntimeException{
+    public JwtException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/ResourceNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/ResourceNotFoundException.java
@@ -2,10 +2,7 @@ package kr.codesquad.issuetraker.exception;
 
 public class ResourceNotFoundException extends RuntimeException {
 
-    public ResourceNotFoundException() {
-
-    }
-    public ResourceNotFoundException(String message) {
+    protected ResourceNotFoundException(String message) {
         super(message);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/exception/RuntimeExceptionHandler.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/exception/RuntimeExceptionHandler.java
@@ -26,4 +26,9 @@ public class RuntimeExceptionHandler {
     public ResponseEntity<GeneralResponseDto> handleInvalidOauthClientNameException(Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new GeneralResponseDto(400, e.getMessage()));
     }
+
+    @ExceptionHandler(value = JwtException.class)
+    public ResponseEntity<GeneralResponseDto> handleJwtException(Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new GeneralResponseDto(401, e.getMessage()));
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/LoginInterceptor.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/LoginInterceptor.java
@@ -1,0 +1,22 @@
+package kr.codesquad.issuetraker.login;
+
+import kr.codesquad.issuetraker.login.jwt.JwtProvider;
+import lombok.AllArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@AllArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String jwtToken = request.getHeader("authorization");
+        jwtProvider.validateToken(jwtToken);
+
+        return true;
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/jwt/JwtProvider.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/jwt/JwtProvider.java
@@ -3,6 +3,8 @@ package kr.codesquad.issuetraker.login.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import kr.codesquad.issuetraker.domain.user.User;
+import kr.codesquad.issuetraker.exception.ExpiredJwtTokenException;
+import kr.codesquad.issuetraker.exception.InvalidJwtTokenException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
@@ -47,17 +49,20 @@ public class JwtProvider {
                     .getBody();
         } catch (SecurityException e) {
             log.info("⚠️Invalid JWT signature.");
+            throw new InvalidJwtTokenException();
         } catch (MalformedJwtException e) {
             log.info("⚠️Invalid JWT token.");
+            throw new InvalidJwtTokenException();
         } catch (ExpiredJwtException e) {
             // TODO : 만료된 토큰 처리
             log.info("⚠️Expired JWT token.");
-            return e.getClaims();
+            throw new ExpiredJwtTokenException();
         } catch (UnsupportedJwtException e) {
             log.info("⚠️Unsupported JWT token.");
+            throw new InvalidJwtTokenException();
         } catch (IllegalArgumentException e) {
             log.info("⚠️JWT token compact of handler are invalid.");
+            throw new InvalidJwtTokenException();
         }
-        return null;
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
@@ -2,6 +2,7 @@ package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
+import lombok.Builder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
@@ -1,8 +1,10 @@
 package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
+import kr.codesquad.issuetraker.dto.GithubAccessTokenResponseDto;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -11,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+@Slf4j
 public class GithubOauthClient extends OauthClient {
     public GithubOauthClient(String clientId, String authServerUrl, String resourceServerUrl, String secretKey) {
         super(clientId, authServerUrl, resourceServerUrl, secretKey);
@@ -23,7 +26,7 @@ public class GithubOauthClient extends OauthClient {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
-        String rawToken = webClient.post()
+        GithubAccessTokenResponseDto rawToken = webClient.post()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("client_id", clientId)
                         .queryParam("client_secret", secretKey)
@@ -34,16 +37,16 @@ public class GithubOauthClient extends OauthClient {
                 .ifNoneMatch("*")
                 .ifModifiedSince(ZonedDateTime.now())
                 .retrieve()
-                .bodyToFlux(String.class)
+                .bodyToFlux(GithubAccessTokenResponseDto.class)
                 .toStream()
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException());
-        return parseToken(rawToken);
+        return parseToken(rawToken.getAccessToken());
     }
 
     @Override
     protected String parseToken(String rawToken) {
-        return String.format("token %s", rawToken.split("" + (char)34)[3]);
+        return String.format("token %s", rawToken);
     }
 
     @Override

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/GithubOauthClient.java
@@ -2,12 +2,42 @@ package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 public class GithubOauthClient extends OauthClient {
     public GithubOauthClient(String clientId, String authServerUrl, String resourceServerUrl, String secretKey) {
         super(clientId, authServerUrl, resourceServerUrl, secretKey);
+    }
+
+    @Override
+    protected String getAccessToken(String authCode) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl(authServerUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        String rawToken = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("client_id", clientId)
+                        .queryParam("client_secret", secretKey)
+                        .queryParam("code", authCode)
+                        .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .ifNoneMatch("*")
+                .ifModifiedSince(ZonedDateTime.now())
+                .retrieve()
+                .bodyToFlux(String.class)
+                .toStream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException());
+        return parseToken(rawToken);
     }
 
     @Override

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
@@ -2,7 +2,12 @@ package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 public class KakaoOauthClient extends OauthClient {
@@ -11,13 +16,41 @@ public class KakaoOauthClient extends OauthClient {
     }
 
     @Override
+    protected String getAccessToken(String authCode) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl(authServerUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        String rawToken = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("client_id", "9dc5e51153cd29428199781510c17a32")
+                        .queryParam("redirect_url", "http://52.79.243.28:8080/login/oauth/callback")
+                        .queryParam("code", authCode)
+                        .queryParam("grant_type", "authorization_code")
+                        .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .ifNoneMatch("*")
+                .ifModifiedSince(ZonedDateTime.now())
+                .retrieve()
+                .bodyToFlux(String.class)
+                .toStream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException());
+        return parseToken(rawToken);
+    }
+
+
+
+    @Override
     protected String parseToken(String rawToken) {
-        return rawToken.split("accessToken=")[1].split(",")[0];
+        return String.format("Bearer %s", rawToken.split("" + (char)34)[3]);
     }
 
     @Override
     protected OauthUserInfo convertToUserInfoFrom(String rawInfo) {
         Map<String, String> infoMap = new Gson().fromJson(rawInfo, Map.class);
-        return new OauthUserInfo(infoMap.get("email"), infoMap.get("name"), OauthClientType.KAKAO);
+        return new OauthUserInfo(infoMap.get("email"), infoMap.get("nickname"), OauthClientType.KAKAO);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
@@ -2,6 +2,7 @@ package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
+import lombok.Builder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/KakaoOauthClient.java
@@ -1,6 +1,7 @@
 package kr.codesquad.issuetraker.login.oauth;
 
 import com.google.gson.Gson;
+import kr.codesquad.issuetraker.dto.KakaoAccessTokenResponseDto;
 import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
 import lombok.Builder;
 import org.springframework.http.HttpHeaders;
@@ -23,7 +24,7 @@ public class KakaoOauthClient extends OauthClient {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
 
-        String rawToken = webClient.post()
+        KakaoAccessTokenResponseDto rawToken = webClient.post()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("client_id", "9dc5e51153cd29428199781510c17a32")
                         .queryParam("redirect_url", "http://52.79.243.28:8080/login/oauth/callback")
@@ -35,18 +36,16 @@ public class KakaoOauthClient extends OauthClient {
                 .ifNoneMatch("*")
                 .ifModifiedSince(ZonedDateTime.now())
                 .retrieve()
-                .bodyToFlux(String.class)
+                .bodyToFlux(KakaoAccessTokenResponseDto.class)
                 .toStream()
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException());
-        return parseToken(rawToken);
+        return parseToken(rawToken.getAccessToken());
     }
-
-
 
     @Override
     protected String parseToken(String rawToken) {
-        return String.format("Bearer %s", rawToken.split("" + (char)34)[3]);
+        return String.format("Bearer %s", rawToken);
     }
 
     @Override

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthClient.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthClient.java
@@ -12,10 +12,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class OauthClient {
-    private String clientId;
-    private String authServerUrl;
-    private String resourceServerUrl;
-    private String secretKey;
+    protected String clientId;
+    protected String authServerUrl;
+    protected String resourceServerUrl;
+    protected String secretKey;
 
     protected OauthClient(String clientId, String authServerUrl, String resourceServerUrl, String secretKey) {
         this.clientId = clientId;
@@ -43,29 +43,7 @@ public abstract class OauthClient {
                 .orElseThrow(() -> new RuntimeException());
     }
 
-    private String getAccessToken(String authCode) {
-        WebClient webClient = WebClient.builder()
-                .baseUrl(authServerUrl)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
-
-        String rawToken = webClient.post()
-                .uri(uriBuilder -> uriBuilder
-                        .queryParam("client_id", clientId)
-                        .queryParam("client_secret", secretKey)
-                        .queryParam("code", authCode)
-                        .build())
-                .accept(MediaType.APPLICATION_JSON)
-                .acceptCharset(StandardCharsets.UTF_8)
-                .ifNoneMatch("*")
-                .ifModifiedSince(ZonedDateTime.now())
-                .retrieve()
-                .bodyToFlux(String.class)
-                .toStream()
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException());
-        return parseToken(rawToken);
-    }
+    protected abstract String getAccessToken(String authCode);
 
     protected abstract String parseToken(String rawToken);
     protected abstract OauthUserInfo convertToUserInfoFrom(String rawInfo);

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthProperties.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthProperties.java
@@ -1,14 +1,10 @@
 package kr.codesquad.issuetraker.login.oauth;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
-@NoArgsConstructor
 public class OauthProperties {
     private String clientId;
     private String authServerUrl;

--- a/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthProperties.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/login/oauth/OauthProperties.java
@@ -1,0 +1,17 @@
+package kr.codesquad.issuetraker.login.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OauthProperties {
+    private String clientId;
+    private String authServerUrl;
+    private String resourceServerUrl;
+    private String secretKey;
+}

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/LoginService.java
@@ -54,10 +54,10 @@ public class LoginService {
         }
     }
 
-    public UserRegistrationResponseDto registerUserWithPassword(UserRegisterRequestDto requestDto) throws NoSuchAlgorithmException {
+    public GeneralResponseDto registerUserWithPassword(UserRegisterRequestDto requestDto) throws NoSuchAlgorithmException {
         PasswordUserInfo userInfo = PasswordUserInfo.ofRegisterRequest(requestDto);
         User registeredUser = registerUser(userInfo);
-        return UserRegistrationResponseDto.of(registeredUser);
+        return new GeneralResponseDto(200, "회원가입에 성공했습니다.");
     }
 
     private User registerUser(UserInfo userInfo) {

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/LoginService.java
@@ -15,10 +15,12 @@ import kr.codesquad.issuetraker.login.userinfo.OauthUserInfo;
 import kr.codesquad.issuetraker.login.userinfo.PasswordUserInfo;
 import kr.codesquad.issuetraker.login.userinfo.UserInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.security.NoSuchAlgorithmException;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class LoginService {
@@ -32,7 +34,7 @@ public class LoginService {
                 .orElseThrow(() -> new InvalidOauthClientNameException());
         OauthUserInfo userInfo = oauthClient.getUserInfo(requestDto.getAuthCode());
         User user = userRepository.findByEmail(userInfo.getEmail())
-                .orElse(registerUser(userInfo));
+                .orElseGet(() -> registerUser(userInfo));
         JwtToken accessToken = jwtProvider.createToken(user, JwtTokenType.ACCESS);
         JwtToken refreshToken = jwtProvider.createToken(user, JwtTokenType.REFRESH);
         return JwtResponseDto.of(accessToken, refreshToken);

--- a/BE/src/main/java/kr/codesquad/issuetraker/sevice/UserService.java
+++ b/BE/src/main/java/kr/codesquad/issuetraker/sevice/UserService.java
@@ -1,0 +1,26 @@
+package kr.codesquad.issuetraker.sevice;
+
+import kr.codesquad.issuetraker.domain.user.User;
+import kr.codesquad.issuetraker.domain.user.UserRepository;
+import kr.codesquad.issuetraker.dto.UserListElementDto;
+import kr.codesquad.issuetraker.dto.UserListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserListResponseDto getAllUsers() {
+        List<User> users = userRepository.findAll();
+        List<UserListElementDto> userElements = users.stream()
+                .map(UserListElementDto::from)
+                .collect(Collectors.toList());
+        return new UserListResponseDto(userElements);
+    }
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: deploy
   sql:
     init:
       mode: always
@@ -8,7 +8,7 @@ spring:
     defer-datasource-initialization: true
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
안녕하세요 로치! 리입니다.
마지막 PR 너무 늦어서 죄송해요 흐...

## 작업 사항
로치가 주신 리뷰 토대로 기존 코드 개선에 집중했습니다.

### 코드리뷰 반영
- @ConfigurationProperties를 적용해 각 oauth 클라이언트별 OauthProperties를 빈 객체로 만들어 사용했습니다.
- parseToken() 메서드에서 의미가 불명확한 상수를 제거했습니다. 
- User 엔티티에 패스워드 비교 메서드인 isSamePassword()를 만들어 비밀번호 검증 로직의 가독성을 높였습니다.

### 로그인 관련
- 지난 PR에서는 깃헙 oauth 인증부터 JWT 토큰 발급까지 완성한 상태였는데요. 카카오도 로직을 완성하고 패스워드로 로그인하는 유저의 경우에도 회원가입 / 로그인 시 JWT 토큰 발급하는 로직 세부사항을 다듬어 완성했습니다.
- 인터셉터를 활용해 로그인 여부를 판단하고 튕겨내는 로직을 구현했습니다.

---

로치가 말씀해 주신 내용들 공부하면서 적용해 보니 확실히 더 좋아지는 지점들이 보여서 뿌듯하고 좋았습니다!
3주 동안 혼자서 진행하는 게 부담도 많이 되었는데, 좋은 리뷰 해주신 덕분에
정말 많이 배우고 재미있게 작업한 것 같아요. 감사합니다!

동시에 제 부족한 부분도 많이 느끼게 되었습니다.
대표적으로
- JPA 관련한 부분에서 디테일한 지식이 부족한 상황이라 OSIV / 트랜잭션 처리 등등 학습하고 더 세부적으로 개선해 볼 예정이고요.
- ConfigurationProperties 적용하다 보니 스프링의 의존성 주입에 대해 헷갈리는 부분이 많은 것 같아 차근차근 다시 공부해 보려고 합니다.
- 말씀해주셨던 테스트와 로깅도 신경을 많이 못 썼는데, 이 부분도 많은 시행착오와 피드백이 필요하다는 생각이 들어서 아쉽네요.

이외에도 혹시 리뷰하시면서 언급 못하셨지만 코드 보면서 **전반적으로 이런 부분에 대한 학습이 더 있으면 좋을 것 같다** 생각하셨던 점이 있으시면 말씀 주시면 감사할 것 같아요!
물론 부족한 부분이 너무 많겠지만, 로치가 생각하시기에 중요한 부분들을 말씀해 주시면 앞으로의 학습에도 좋은 이정표가 될 것 같습니다.

로치 덕분에 코쿼 마지막 프로젝트 잘 마무리할 수 있었습니다.
정말 감사합니다!-!